### PR TITLE
Adds Kibana ISM cluster

### DIFF
--- a/server/clusters/index.ts
+++ b/server/clusters/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import createISMCluster from "./ism/createISMCluster";
+
+export { createISMCluster };

--- a/server/clusters/ism/createISMCluster.ts
+++ b/server/clusters/ism/createISMCluster.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { Legacy } from "kibana";
+import ismPlugin from "./ismPlugin";
+import { CLUSTER, DEFAULT_HEADERS } from "../../utils/constants";
+import Server = Legacy.Server;
+
+export default function createISMCluster(server: Server) {
+  const { customHeaders, ...rest } = server.config().get("elasticsearch");
+  server.plugins.elasticsearch.createCluster(CLUSTER.ISM, {
+    plugins: [ismPlugin],
+    customHeaders: { ...customHeaders, ...DEFAULT_HEADERS },
+    ...rest,
+  });
+}

--- a/server/clusters/ism/ismPlugin.ts
+++ b/server/clusters/ism/ismPlugin.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { API } from "../../utils/constants";
+
+/*
+ * Types are not available until 7.2
+ * https://github.com/elastic/kibana/blob/v7.2.0/src/core/server/elasticsearch/elasticsearch_client_config.ts
+ * */
+export default function ismPlugin(Client: any, config: any, components: any) {
+  const ca = components.clientAction.factory;
+
+  Client.prototype.ism = components.clientAction.namespaceFactory();
+  const ism = Client.prototype.ism.prototype;
+
+  ism.getPolicy = ca({
+    url: {
+      fmt: `${API.POLICY_BASE}/<%=policyId%>`,
+      req: {
+        policyId: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    method: "GET",
+  });
+
+  ism.createPolicy = ca({
+    url: {
+      fmt: `${API.POLICY_BASE}/<%=policyId%>?refresh=wait_for`,
+      req: {
+        policyId: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: "PUT",
+  });
+
+  ism.deletePolicy = ca({
+    url: {
+      fmt: `${API.POLICY_BASE}/<%=policyId%>?refresh=wait_for`,
+      req: {
+        policyId: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    method: "DELETE",
+  });
+
+  ism.putPolicy = ca({
+    url: {
+      fmt: `${API.POLICY_BASE}/<%=policyId%>?if_seq_no=<%=ifSeqNo%>&if_primary_term=<%=ifPrimaryTerm%>&refresh=wait_for`,
+      req: {
+        policyId: {
+          type: "string",
+          required: true,
+        },
+        ifSeqNo: {
+          type: "string",
+          required: true,
+        },
+        ifPrimaryTerm: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    needBody: true,
+    method: "PUT",
+  });
+
+  ism.explain = ca({
+    url: {
+      fmt: `${API.EXPLAIN_BASE}/<%=index%>`,
+      req: {
+        index: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    method: "GET",
+  });
+
+  ism.retry = ca({
+    url: {
+      fmt: `${API.RETRY_BASE}/<%=index%>`,
+      req: {
+        index: {
+          type: "string",
+          required: true,
+        },
+      },
+    },
+    needBody: false,
+    method: "POST",
+  });
+
+  // TODO add new APIs as they are being implemented: add, remove, change, status, stop, start
+}

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export interface IndexManagementApi {
+  [API_ROUTE: string]: string;
+  readonly POLICY_BASE: string;
+  readonly EXPLAIN_BASE: string;
+  readonly RETRY_BASE: string;
+}
+
+export interface DefaultHeaders {
+  "Content-Type": "application/json";
+  Accept: "application/json";
+}

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { DefaultHeaders, IndexManagementApi } from "../models/interfaces";
+
+export const API_ROUTE_PREFIX = "/_opendistro/_ism";
+
+export const API: IndexManagementApi = {
+  POLICY_BASE: `${API_ROUTE_PREFIX}/policies`,
+  EXPLAIN_BASE: `${API_ROUTE_PREFIX}/explain`,
+  RETRY_BASE: `${API_ROUTE_PREFIX}/retry`,
+};
+
+export const DEFAULT_HEADERS: DefaultHeaders = {
+  "Content-Type": "application/json",
+  Accept: "application/json",
+};
+
+export enum CLUSTER {
+  ADMIN = "admin",
+  ISM = "opendistro_ism",
+  DATA = "data",
+}
+
+export enum INDEX {
+  OPENDISTRO_ISM_CONFIG = ".opendistro-ism-config",
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds the Kibana Cluster that allows us to forward the nodejs requests to our backend plugin w/ the authorization headers.

For reference refer to:
https://github.com/opendistro-for-elasticsearch/alerting-kibana-plugin/tree/master/server/clusters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
