### PR TITLE
Adds temporary RefreshPicker

### DIFF
--- a/public/temporary/AsyncInterval.ts
+++ b/public/temporary/AsyncInterval.ts
@@ -1,0 +1,30 @@
+// Code from https://github.com/elastic/eui
+// Used under the Apache-2.0 license.
+
+// This is from EUI library, but cannot be used until we are at 7.2+
+// This is a temporary import for 7.0 and 7.1
+export default class AsyncInterval {
+  timeoutId: number | undefined;
+  isStopped: boolean = false;
+  __pendingFn: Function | undefined;
+
+  constructor(fn: Function, refreshInterval: number) {
+    this.setAsyncInterval(fn, refreshInterval);
+  }
+
+  setAsyncInterval = (fn: Function, ms: number) => {
+    if (!this.isStopped) {
+      this.timeoutId = window.setTimeout(async () => {
+        if (document.visibilityState === "visible") {
+          this.__pendingFn = await fn();
+        }
+        this.setAsyncInterval(fn, ms);
+      }, ms);
+    }
+  };
+
+  stop = () => {
+    this.isStopped = true;
+    window.clearTimeout(this.timeoutId);
+  };
+}

--- a/public/temporary/EuiRefreshPicker.tsx
+++ b/public/temporary/EuiRefreshPicker.tsx
@@ -1,0 +1,70 @@
+// Code from https://github.com/elastic/eui
+// Used under the Apache-2.0 license.
+
+import React, { Component } from "react";
+import { EuiSuperDatePicker } from "@elastic/eui";
+import AsyncInterval from "./AsyncInterval";
+
+interface EuiRefreshPickerProps {
+  isPaused: boolean;
+  refreshInterval: number;
+  onRefresh: Function;
+  onRefreshChange: Function;
+}
+
+// Some of this code is from EUI library, but cannot be used until we are at 7.2+
+// This is a temporary import for 7.0 and 7.1
+export default class EuiRefreshPicker extends Component<EuiRefreshPickerProps> {
+  asyncInterval: AsyncInterval | undefined;
+
+  componentDidMount = () => {
+    if (!this.props.isPaused) {
+      this.startInterval(this.props.refreshInterval);
+    }
+  };
+
+  componentWillUnmount = () => {
+    this.stopInterval();
+  };
+
+  onRefreshChange = ({ refreshInterval, isPaused }: { refreshInterval: number; isPaused: boolean }) => {
+    this.stopInterval();
+    if (!isPaused) {
+      this.startInterval(refreshInterval);
+    }
+    if (this.props.onRefreshChange) {
+      this.props.onRefreshChange({ refreshInterval, isPaused });
+    }
+  };
+
+  stopInterval = () => {
+    if (this.asyncInterval) {
+      this.asyncInterval.stop();
+    }
+  };
+
+  startInterval = (refreshInterval: number) => {
+    const { onRefresh } = this.props;
+    if (onRefresh) {
+      const handler = () => {
+        onRefresh({ refreshInterval });
+      };
+      this.asyncInterval = new AsyncInterval(handler, refreshInterval);
+    }
+  };
+
+  // Current version of EuiSuperDatePicker requires onTimeChange even if we don't use it
+  onTimeChange = () => {};
+
+  render() {
+    return (
+      <EuiSuperDatePicker
+        isAutoRefreshOnly
+        isPaused={this.props.isPaused}
+        refreshInterval={this.props.refreshInterval}
+        onRefreshChange={this.onRefreshChange}
+        onTimeChange={this.onTimeChange}
+      />
+    );
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds temporary RefreshPicker
This also lives in the EUI component library, but at a later version which we do not have yet. So this is a temporary import so that we can use the same interface/functionality in our code and easily switch to it once we are targeting version 7.2+

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
