### PR TITLE
Adds rollover alias to add policy

### DIFF
--- a/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.test.tsx
+++ b/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.test.tsx
@@ -47,7 +47,7 @@ describe("<AddPolicyModal /> spec", () => {
     render(<AddPolicyModal onClose={() => {}} services={browserServicesMock} indices={[]} />);
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("");
+    expect(spy).toHaveBeenCalledWith("", true);
     expect(toastNotifications.addDanger).not.toHaveBeenCalled();
   });
 
@@ -60,7 +60,7 @@ describe("<AddPolicyModal /> spec", () => {
     await wait();
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("");
+    expect(spy).toHaveBeenCalledWith("", true);
     expect(toastNotifications.addDanger).toHaveBeenCalledTimes(1);
     expect(toastNotifications.addDanger).toHaveBeenCalledWith("some error");
   });
@@ -74,7 +74,7 @@ describe("<AddPolicyModal /> spec", () => {
     await wait();
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("");
+    expect(spy).toHaveBeenCalledWith("", true);
     expect(toastNotifications.addDanger).toHaveBeenCalledTimes(1);
     expect(toastNotifications.addDanger).toHaveBeenCalledWith("testing error");
   });

--- a/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
@@ -25,9 +25,14 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiComboBox,
+  EuiFormRow,
+  EuiFieldText,
+  EuiCallOut,
 } from "@elastic/eui";
 import { BrowserServices } from "../../../../models/interfaces";
 import { PolicyOption } from "../../models/interfaces";
+import { Policy } from "../../../../../models/interfaces";
+import { getErrorMessage } from "../../../../utils/helpers";
 
 interface AddPolicyModalProps {
   onClose: () => void;
@@ -37,39 +42,51 @@ interface AddPolicyModalProps {
 
 interface AddPolicyModalState {
   isLoading: boolean;
-  selectedPolicies: PolicyOption[];
+  selectedPolicy: PolicyOption | null;
+  hasRolloverAction: boolean;
   policyOptions: PolicyOption[];
+  rolloverAlias: string;
 }
 
 export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPolicyModalState> {
   state: AddPolicyModalState = {
     isLoading: false,
-    selectedPolicies: [],
+    selectedPolicy: null,
+    hasRolloverAction: false,
     policyOptions: [],
+    rolloverAlias: "",
   };
 
-  async componentDidMount() {
+  async componentDidMount(): Promise<void> {
     await this.onPolicySearchChange("");
   }
 
   onAddPolicy = async (): Promise<void> => {
     try {
-      const { selectedPolicies } = this.state;
+      const { selectedPolicy, hasRolloverAction, rolloverAlias } = this.state;
       const {
         onClose,
         indices,
         services: { indexService },
       } = this.props;
-      if (selectedPolicies.length !== 1) {
-        toastNotifications.addDanger(`There are no selected indices`);
+      if (!indices) {
+        toastNotifications.addDanger("There are no selected indices");
         return;
       }
-      const policyId = selectedPolicies[0].label;
+      if (!selectedPolicy) {
+        toastNotifications.addDanger("There is no selected policy");
+        return;
+      }
+
+      const policyId = selectedPolicy.label;
       const addPolicyResponse = await indexService.addPolicy(indices, policyId);
       if (addPolicyResponse.ok) {
         const { updatedIndices, failedIndices, failures } = addPolicyResponse.response;
         if (updatedIndices) {
           toastNotifications.addSuccess(`Added policy to ${updatedIndices} indices`);
+          if (hasRolloverAction && rolloverAlias && indices.length === 1) {
+            await this.onAddRolloverAlias(indices[0], rolloverAlias);
+          }
         }
         if (failures) {
           toastNotifications.addDanger(
@@ -81,7 +98,27 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
         toastNotifications.addDanger(addPolicyResponse.error);
       }
     } catch (err) {
-      toastNotifications.addDanger(err.message);
+      toastNotifications.addDanger(getErrorMessage(err, "There was a problem adding policy to indices"));
+    }
+  };
+
+  onAddRolloverAlias = async (index: string, rolloverAlias: string): Promise<void> => {
+    const {
+      services: { indexService },
+    } = this.props;
+    try {
+      const response = await indexService.addRolloverAlias(index, rolloverAlias);
+      if (response.ok) {
+        if (response.response.acknowledged) {
+          toastNotifications.addSuccess(`Added rollover alias to ${index}`);
+        } else {
+          toastNotifications.addDanger(`Failed to add rollover alias to ${index}`);
+        }
+      } else {
+        toastNotifications.addDanger(response.error);
+      }
+    } catch (err) {
+      toastNotifications.addDanger(getErrorMessage(err, `There was a problem adding rollover alias to ${index}`));
     }
   };
 
@@ -91,10 +128,13 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
     } = this.props;
     this.setState({ isLoading: true, policyOptions: [] });
     try {
-      const searchPoliciesResponse = await indexService.searchPolicies(searchValue);
+      const searchPoliciesResponse = await indexService.searchPolicies(searchValue, true);
       if (searchPoliciesResponse.ok) {
-        const policies = searchPoliciesResponse.response.hits.hits.map((hit: { _id: string }) => hit._id);
-        this.setState({ policyOptions: policies.map((policyId: string) => ({ label: policyId })) });
+        const policies = searchPoliciesResponse.response.hits.hits.map((hit: { _id: string; _source: { policy: Policy } }) => ({
+          label: hit._id,
+          policy: hit._source.policy,
+        }));
+        this.setState({ policyOptions: policies });
       } else {
         if (searchPoliciesResponse.error.startsWith("[index_not_found_exception]")) {
           toastNotifications.addDanger("You have not created a policy yet");
@@ -109,13 +149,55 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
     this.setState({ isLoading: false });
   };
 
-  onChange = (selectedPolicies: PolicyOption[]): void => {
-    this.setState({ selectedPolicies });
+  onChangeSelectedPolicy = (selectedPolicies: PolicyOption[]): void => {
+    const selectedPolicy = selectedPolicies.length ? selectedPolicies[0] : null;
+    const hasRolloverAction =
+      !!selectedPolicy &&
+      !!selectedPolicy.policy &&
+      selectedPolicy.policy.states.some(state => state.actions.some(action => action.hasOwnProperty("rollover")));
+    this.setState({ selectedPolicy, hasRolloverAction });
+  };
+
+  onChangeRolloverAlias = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    this.setState({ rolloverAlias: e.target.value });
+  };
+
+  renderRollover = () => {
+    const { rolloverAlias, hasRolloverAction } = this.state;
+    const { indices } = this.props;
+    const hasSingleIndexSelected = indices.length === 1;
+
+    if (!hasRolloverAction) return null;
+
+    if (hasSingleIndexSelected) {
+      return (
+        <EuiFormRow label="Rollover alias" helpText="A rollover alias is required when using the rollover action">
+          <EuiFieldText placeholder="Rollover alias" value={rolloverAlias} onChange={this.onChangeRolloverAlias} />
+        </EuiFormRow>
+      );
+    }
+
+    return (
+      <EuiCallOut
+        style={{ width: "350px" }}
+        title={
+          <p>
+            You are applying a policy with rollover to multiple indices. You will need to add a unique rollover_alias setting to each index.
+          </p>
+        }
+        iconType="alert"
+        size="s"
+        color="warning"
+      />
+    );
   };
 
   render() {
-    const { policyOptions, selectedPolicies, isLoading } = this.state;
-    const { onClose } = this.props;
+    const { policyOptions, selectedPolicy, isLoading, rolloverAlias, hasRolloverAction } = this.state;
+    const { onClose, indices } = this.props;
+    const selectedOptions = selectedPolicy ? [selectedPolicy] : [];
+    const hasSingleIndexSelected = indices.length === 1;
+    const isAddDisabled = !selectedPolicy || (hasSingleIndexSelected && hasRolloverAction && !rolloverAlias);
     return (
       <EuiOverlayMask>
         {/*
@@ -126,16 +208,19 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
           </EuiModalHeader>
 
           <EuiModalBody>
-            <EuiComboBox
-              placeholder="Search policies"
-              async
-              options={policyOptions}
-              singleSelection
-              selectedOptions={selectedPolicies}
-              isLoading={isLoading}
-              onChange={this.onChange}
-              onSearchChange={this.onPolicySearchChange}
-            />
+            <EuiFormRow label="Policy" helpText="Select the policy you want to add to the indices">
+              <EuiComboBox
+                placeholder="Search policies"
+                async
+                options={policyOptions}
+                singleSelection={{ asPlainText: true }}
+                selectedOptions={selectedOptions}
+                isLoading={isLoading}
+                onChange={this.onChangeSelectedPolicy}
+                onSearchChange={this.onPolicySearchChange}
+              />
+            </EuiFormRow>
+            {this.renderRollover()}
           </EuiModalBody>
 
           <EuiModalFooter>
@@ -143,7 +228,7 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
               Close
             </EuiButtonEmpty>
 
-            <EuiButton disabled={selectedPolicies.length !== 1} onClick={this.onAddPolicy} fill data-test-subj="addPolicyModalEditButton">
+            <EuiButton disabled={isAddDisabled} onClick={this.onAddPolicy} fill data-test-subj="addPolicyModalEditButton">
               Add
             </EuiButton>
           </EuiModalFooter>

--- a/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
@@ -15,6 +15,7 @@
 
 import React, { Component } from "react";
 import { toastNotifications } from "ui/notify";
+import _ from "lodash";
 import {
   EuiButton,
   EuiButtonEmpty,
@@ -31,7 +32,7 @@ import {
 } from "@elastic/eui";
 import { BrowserServices } from "../../../../models/interfaces";
 import { PolicyOption } from "../../models/interfaces";
-import { Policy } from "../../../../../models/interfaces";
+import { Policy, State } from "../../../../../models/interfaces";
 import { getErrorMessage } from "../../../../utils/helpers";
 
 interface AddPolicyModalProps {
@@ -151,10 +152,9 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
 
   onChangeSelectedPolicy = (selectedPolicies: PolicyOption[]): void => {
     const selectedPolicy = selectedPolicies.length ? selectedPolicies[0] : null;
-    const hasRolloverAction =
-      !!selectedPolicy &&
-      !!selectedPolicy.policy &&
-      selectedPolicy.policy.states.some(state => state.actions.some(action => action.hasOwnProperty("rollover")));
+    const hasRolloverAction = _.get(selectedPolicy, "policy.states", []).some((state: State) =>
+      state.actions.some(action => action.hasOwnProperty("rollover"))
+    );
     this.setState({ selectedPolicy, hasRolloverAction });
   };
 

--- a/public/pages/Indices/components/AddPolicyModal/__snapshots__/AddPolicyModal.test.tsx.snap
+++ b/public/pages/Indices/components/AddPolicyModal/__snapshots__/AddPolicyModal.test.tsx.snap
@@ -56,74 +56,93 @@ exports[`<AddPolicyModal /> spec renders the component 1`] = `
           class="euiModalBody"
         >
           <div
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            class="euiComboBox"
-            role="combobox"
+            class="euiFormRow"
+            id="some_make_id-row"
           >
+            <label
+              class="euiFormLabel"
+              for="some_make_id"
+            >
+              Policy
+            </label>
             <div
-              class="euiFormControlLayout"
+              aria-describedby="some_make_id-help"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="euiComboBox"
+              role="combobox"
             >
               <div
-                class="euiFormControlLayout__childrenWrapper"
+                class="euiFormControlLayout"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                  data-test-subj="comboBoxInput"
-                  tabindex="-1"
+                  class="euiFormControlLayout__childrenWrapper"
                 >
-                  <p
-                    class="euiComboBoxPlaceholder"
-                  >
-                    Search policies
-                  </p>
                   <div
-                    class="euiComboBox__input"
-                    style="font-size: 14px; display: inline-block;"
+                    class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                    data-test-subj="comboBoxInput"
+                    tabindex="-1"
                   >
-                    <input
-                      data-test-subj="comboBoxSearchInput"
-                      role="textbox"
-                      style="box-sizing: content-box; width: 2px;"
-                      value=""
-                    />
+                    <p
+                      class="euiComboBoxPlaceholder"
+                    >
+                      Search policies
+                    </p>
                     <div
-                      style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
-                    />
+                      class="euiComboBox__input"
+                      style="font-size: 14px; display: inline-block;"
+                    >
+                      <input
+                        data-test-subj="comboBoxSearchInput"
+                        id="some_make_id"
+                        role="textbox"
+                        style="box-sizing: content-box; width: 2px;"
+                        value=""
+                      />
+                      <div
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                  >
+                    <button
+                      aria-label="Open list of options"
+                      class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                      data-test-subj="comboBoxToggleListButton"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                        focusable="false"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                      >
+                        <defs>
+                          <path
+                            d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
+                            id="arrow_down-a"
+                          />
+                        </defs>
+                        <use
+                          fill-rule="nonzero"
+                          xlink:href="#arrow_down-a"
+                        />
+                      </svg>
+                    </button>
                   </div>
                 </div>
-                <div
-                  class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                >
-                  <button
-                    aria-label="Open list of options"
-                    class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                    data-test-subj="comboBoxToggleListButton"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                      focusable="false"
-                      height="16"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                    >
-                      <defs>
-                        <path
-                          d="M13.069 5.157L8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0z"
-                          id="arrow_down-a"
-                        />
-                      </defs>
-                      <use
-                        fill-rule="nonzero"
-                        xlink:href="#arrow_down-a"
-                      />
-                    </svg>
-                  </button>
-                </div>
               </div>
+            </div>
+            <div
+              class="euiFormHelpText euiFormRow__text"
+              id="some_make_id-help"
+            >
+              Select the policy you want to add to the indices
             </div>
           </div>
         </div>

--- a/public/pages/Indices/components/AddPolicyModal/__snapshots__/AddPolicyModal.test.tsx.snap
+++ b/public/pages/Indices/components/AddPolicyModal/__snapshots__/AddPolicyModal.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`<AddPolicyModal /> spec renders the component 1`] = `
             id="some_make_id-row"
           >
             <label
+              aria-invalid="false"
               class="euiFormLabel"
               for="some_make_id"
             >
@@ -167,7 +168,6 @@ exports[`<AddPolicyModal /> spec renders the component 1`] = `
           <button
             class="euiButton euiButton--primary euiButton--fill"
             data-test-subj="addPolicyModalEditButton"
-            disabled=""
             type="button"
           >
             <span

--- a/public/pages/Indices/models/interfaces.ts
+++ b/public/pages/Indices/models/interfaces.ts
@@ -14,9 +14,11 @@
  */
 
 import { SortDirection } from "../../../utils/constants";
+import { Policy } from "../../../../models/interfaces";
 
 export interface PolicyOption {
   label: string;
+  policy?: Policy;
 }
 
 export interface IndicesQueryParams {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use rollover alias in add policy
When adding a policy to an index it checks if that policy has a rollover action.
If it does it uses progressive disclosure to show an extra input for the rollover alias that is required.

If there are more than one indices selected for adding a policy it will instead show a warning as rollover alias -> index is 1:1 and as of now we do not want to potentially show 2-50 input boxes in the modal. Eventually we will move this into its own page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
