### PR TITLE
Fixes issue with double ??s for query parameters and rolloverAlias no…

### DIFF
--- a/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
+++ b/public/pages/ChangePolicy/components/ChangeManagedIndices/ChangeManagedIndices.tsx
@@ -51,7 +51,7 @@ export default class ChangeManagedIndices extends Component<ChangeManagedIndices
     this.setState({ managedIndicesIsLoading: true, managedIndices: [] });
     try {
       // only bring back the first 10 results descending by name
-      const queryParamsString = `?from=0&size=10&search=${searchValue}&sortDirection=desc&sortField=name`;
+      const queryParamsString = `from=0&size=10&search=${searchValue}&sortDirection=desc&sortField=name`;
       const managedIndicesResponse = await managedIndexService.getManagedIndices(queryParamsString);
       if (managedIndicesResponse.ok) {
         const options = searchValue.trim() ? [{ label: `${searchValue}*` }] : [];

--- a/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/public/pages/Indices/components/AddPolicyModal/AddPolicyModal.tsx
@@ -173,7 +173,7 @@ export default class AddPolicyModal extends Component<AddPolicyModalProps, AddPo
       this.setState({ selectedPolicyError, rolloverAliasError, hasSubmitted: true });
     } else {
       // @ts-ignore
-      await this.onAddPolicy(selectedPolicy, this.hasRolloverAction(), rolloverAlias);
+      await this.onAddPolicy(selectedPolicy, this.hasRolloverAction(selectedPolicy), rolloverAlias);
     }
   };
 


### PR DESCRIPTION
…t being added

*Issue #, if available:*

*Description of changes:*
400 request because of double ??s in network call
rolloverAlias not being added in AddPolicy modal because it was always defaulting to false for having a policy with rollover action

We have an issue with EUI for testing the AddPolicyModal so we have lack of testing around this modal, need to deep dive to find fix so we can add better tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
