### PR TITLE
Change pull_request to push event in test workflow

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -1,6 +1,6 @@
 name: Unit tests workflow
 on:
-  pull_request:
+  push:
     branches:
       - master
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This workflow cannot successfully run when a PR is made from a fork as it does not have access to the secret to pull down the private Kibana repository. Will change it to be push instead so it can run once PR is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
