### PR TITLE
Create Rollup job step 2: Time aggregation component

### DIFF
--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -30,15 +30,14 @@ import { CalenderTimeunitOptions, FixedTimeunitOptions, TimezoneOptions } from "
 
 interface TimeAggregationProps {
   intervalType: string;
-  onChange: (value: ChangeEvent<HTMLInputElement>) => void;
-  timestampOptions: EuiComboBoxOptionOption<String>[];
   selectedTimestamp: EuiComboBoxOptionOption<String>[];
+  timestampOptions: EuiComboBoxOptionOption<String>[];
+  timeunit: string;
+  timezone: string;
   onChangeIntervalType: (optionId: string) => void;
   onChangeTimestamp: (options: EuiComboBoxOptionOption<String>[]) => void;
-  onChangeTimezone: (e: ChangeEvent<HTMLSelectElement>) => void;
   onChangeTimeunit: (e: ChangeEvent<HTMLSelectElement>) => void;
-  timezone: string;
-  timeunit: string;
+  onChangeTimezone: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
 
 const radios = [
@@ -57,7 +56,17 @@ export default class TimeAggregation extends Component<TimeAggregationProps> {
   }
 
   render() {
-    const { timestampOptions, intervalType, timezone, timeunit, onChangeTimezone, onChangeIntervalType, onChangeTimeunit } = this.props;
+    const {
+      intervalType,
+      selectedTimestamp,
+      timestampOptions,
+      timeunit,
+      timezone,
+      onChangeIntervalType,
+      onChangeTimestamp,
+      onChangeTimeunit,
+      onChangeTimezone,
+    } = this.props;
     return (
       <ContentPanel bodyStyles={{ padding: "initial" }} title="Time aggregation" titleSize="s">
         <div style={{ paddingLeft: "10px" }}>
@@ -66,8 +75,8 @@ export default class TimeAggregation extends Component<TimeAggregationProps> {
             <EuiComboBox
               placeholder="Select timestamp"
               options={timestampOptions}
-              selectedOptions={this.props.selectedTimestamp}
-              onChange={this.props.onChangeTimestamp}
+              selectedOptions={selectedTimestamp}
+              onChange={onChangeTimestamp}
               singleSelection={true}
             />
           </EuiFormRow>

--- a/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
+++ b/public/pages/CreateRollup/components/TimeAggregations/TimeAggregation.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { ChangeEvent, Component } from "react";
+import {
+  EuiSpacer,
+  EuiFormRow,
+  EuiComboBox,
+  EuiSelect,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFieldNumber,
+  EuiRadioGroup,
+  EuiComboBoxOptionOption,
+} from "@elastic/eui";
+import { ContentPanel } from "../../../../components/ContentPanel";
+import { CalenderTimeunitOptions, FixedTimeunitOptions, TimezoneOptions } from "../../utils/constants";
+
+interface TimeAggregationProps {
+  intervalType: string;
+  onChange: (value: ChangeEvent<HTMLInputElement>) => void;
+  timestampOptions: EuiComboBoxOptionOption<String>[];
+  selectedTimestamp: EuiComboBoxOptionOption<String>[];
+  onChangeIntervalType: (optionId: string) => void;
+  onChangeTimestamp: (options: EuiComboBoxOptionOption<String>[]) => void;
+  onChangeTimezone: (e: ChangeEvent<HTMLSelectElement>) => void;
+  onChangeTimeunit: (e: ChangeEvent<HTMLSelectElement>) => void;
+  timezone: string;
+  timeunit: string;
+}
+
+const radios = [
+  {
+    id: "fixed",
+    label: "Fixed",
+  },
+  {
+    id: "calender",
+    label: "Calender",
+  },
+];
+export default class TimeAggregation extends Component<TimeAggregationProps> {
+  constructor(props: TimeAggregationProps) {
+    super(props);
+  }
+
+  render() {
+    const { timestampOptions, intervalType, timezone, timeunit, onChangeTimezone, onChangeIntervalType, onChangeTimeunit } = this.props;
+    return (
+      <ContentPanel bodyStyles={{ padding: "initial" }} title="Time aggregation" titleSize="s">
+        <div style={{ paddingLeft: "10px" }}>
+          <EuiSpacer size="s" />
+          <EuiFormRow label="Timestamp field">
+            <EuiComboBox
+              placeholder="Select timestamp"
+              options={timestampOptions}
+              selectedOptions={this.props.selectedTimestamp}
+              onChange={this.props.onChangeTimestamp}
+              singleSelection={true}
+            />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFormRow label="Interval type">
+            <EuiRadioGroup options={radios} idSelected={intervalType} onChange={(id) => onChangeIntervalType(id)} name="intervalType" />
+          </EuiFormRow>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup style={{ maxWidth: 300 }}>
+            <EuiFlexItem grow={false} style={{ width: 100 }}>
+              <EuiFormRow label="Interval">
+                <EuiFieldNumber min={1} placeholder="2" />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow hasEmptyLabelSpace={true}>
+                <EuiSelect
+                  id="selectTimeunit"
+                  options={intervalType == "fixed" ? FixedTimeunitOptions : CalenderTimeunitOptions}
+                  value={timeunit}
+                  onChange={onChangeTimeunit}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiSpacer size="m" />
+          <EuiFormRow label="Timezone">
+            <EuiSelect id="timezone" options={TimezoneOptions} value={timezone} onChange={onChangeTimezone} />
+          </EuiFormRow>
+        </div>
+      </ContentPanel>
+    );
+  }
+}

--- a/public/pages/CreateRollup/components/TimeAggregations/index.ts
+++ b/public/pages/CreateRollup/components/TimeAggregations/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import TimeAggregation from "./TimeAggregation";
+
+export default TimeAggregation;

--- a/public/pages/CreateRollup/utils/constants.ts
+++ b/public/pages/CreateRollup/utils/constants.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+export const FixedTimeunitOptions = [
+  { value: "ms", text: "Millisecond(s)" },
+  { value: "s", text: "Second(s)" },
+  { value: "m", text: "Minute(s)" },
+  { value: "h", text: "Hour(s)" },
+  { value: "d", text: "Day(s)" },
+];
+
+export const CalenderTimeunitOptions = [
+  { value: "m", text: "Minute(s)" },
+  { value: "h", text: "Hour(s)" },
+  { value: "d", text: "Day(s)" },
+  { value: "w", text: "Week(s)" },
+  { value: "M", text: "Month(s)" },
+  { value: "q", text: "Quarter(s)" },
+  { value: "y", text: "Year(s)" },
+];
+
+export const TimezoneOptions = [
+  { value: "12", text: "UTC +12" },
+  { value: "11", text: "UTC +11" },
+  { value: "10", text: "UTC +10" },
+  { value: "9", text: "UTC +9" },
+  { value: "8", text: "UTC +8" },
+  { value: "7", text: "UTC +7" },
+  { value: "6", text: "UTC +6" },
+  { value: "5", text: "UTC +5" },
+  { value: "4", text: "UTC +4" },
+  { value: "3", text: "UTC +3" },
+  { value: "2", text: "UTC +2" },
+  { value: "1", text: "UTC +1" },
+  { value: "0", text: "UTC +0" },
+  { value: "-1", text: "UTC -1" },
+  { value: "-2", text: "UTC -2" },
+  { value: "-3", text: "UTC -3" },
+  { value: "-4", text: "UTC -4" },
+  { value: "-5", text: "UTC -5" },
+  { value: "-6", text: "UTC -6" },
+  { value: "-7", text: "UTC -7" },
+  { value: "-8", text: "UTC -8" },
+  { value: "-9", text: "UTC -9" },
+  { value: "-10", text: "UTC -10" },
+  { value: "-11", text: "UTC -11" },
+  { value: "-12", text: "UTC -12" },
+];


### PR DESCRIPTION

*Description of changes:*
Time aggregation component of rollup creation step 2 page.

**Screenshots:**

<img width="668" alt="image" src="https://user-images.githubusercontent.com/71157062/95399514-32429e80-08bd-11eb-8ee5-194f9dcaff6b.png">

Options when define interval by fixed time unit: 
<img width="667" alt="image" src="https://user-images.githubusercontent.com/71157062/95399353-da0b9c80-08bc-11eb-92ba-09d03e076088.png">

Options when define interval by calendar time unit: 
<img width="667" alt="image" src="https://user-images.githubusercontent.com/71157062/95399465-1b9c4780-08bd-11eb-9253-d1684171e975.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
