### PR TITLE
use modified explain API

### DIFF
--- a/server/clusters/ism/ismPlugin.ts
+++ b/server/clusters/ism/ismPlugin.ts
@@ -100,6 +100,13 @@ export default function ismPlugin(Client: any, config: any, components: any) {
     method: "GET",
   });
 
+  ism.explainAll = ca({
+    url: {
+      fmt: `${API.EXPLAIN_BASE}`,
+    },
+    method: "GET",
+  });
+
   ism.retry = ca({
     url: {
       fmt: `${API.RETRY_BASE}/<%=index%>`,

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -140,7 +140,7 @@ export interface ExplainAPIManagedIndexMetaData {
   action?: { name: string; start_time: number; index: number; failed: boolean; consumed_retries: number };
   retry_info?: { failed: boolean; consumed_retries: number };
   info?: object;
-  enabled: boolean;
+  enabled?: boolean;
 }
 
 export interface IndexManagementApi {

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -30,7 +30,8 @@ export interface SearchResponse<T> {
 }
 
 export interface ExplainResponse {
-  [index: string]: ExplainAPIManagedIndexMetaData;
+  [index: string]: ExplainAPIManagedIndexMetaData | number;
+  totalManagedIndices: number;
 }
 
 export interface GetManagedIndicesResponse {
@@ -139,6 +140,7 @@ export interface ExplainAPIManagedIndexMetaData {
   action?: { name: string; start_time: number; index: number; failed: boolean; consumed_retries: number };
   retry_info?: { failed: boolean; consumed_retries: number };
   info?: object;
+  enabled: boolean;
 }
 
 export interface IndexManagementApi {

--- a/server/models/interfaces.ts
+++ b/server/models/interfaces.ts
@@ -30,7 +30,7 @@ export interface SearchResponse<T> {
 }
 
 export interface ExplainResponse {
-  [index: string]: ExplainAPIManagedIndexMetaData | undefined;
+  [index: string]: ExplainAPIManagedIndexMetaData;
 }
 
 export interface GetManagedIndicesResponse {
@@ -126,10 +126,10 @@ export interface FailedIndex {
 }
 
 export interface ExplainAPIManagedIndexMetaData {
-  "opendistro.index_state_management.policy_id": string | null;
-  index?: string;
-  index_uuid?: string;
-  policy_id?: string;
+  "index.opendistro.index_state_management.policy_id": string | null;
+  index: string;
+  index_uuid: string;
+  policy_id: string;
   policy_seq_no?: number;
   policy_primary_term?: number;
   policy_completed?: boolean;

--- a/server/services/ManagedIndexService.ts
+++ b/server/services/ManagedIndexService.ts
@@ -57,9 +57,7 @@ export default class ManagedIndexService {
     }
   };
 
-  getManagedIndices2 = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
-    // console.log('get managedindices request', req);
-
+  getManagedIndices = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
     try {
       const { from, size, search, sortDirection, sortField } = req.query as {
         from: string;
@@ -69,10 +67,7 @@ export default class ManagedIndexService {
         sortField: string;
       };
 
-      console.log(`check variables: ${from}, ${size}, ${search}, ${sortDirection}, ${sortField}`);
-
       const managedIndexSorts: ManagedIndicesSort = { index: "managed_index.index", policyId: "managed_index.policy_id" };
-
       const explainParams = {
         size,
         from,
@@ -86,12 +81,8 @@ export default class ManagedIndexService {
 
       const managedIndices = [];
       for (const index in explainResponse) {
-        console.log(`index ${index}`);
         if (index === "totalManagedIndices") continue;
-
         const explain = explainResponse[index] as ExplainAPIManagedIndexMetaData;
-        console.log(`explain index: ${explain.index}`);
-        console.log(`policy id:  ${explain.policy_id}`);
 
         let policy, seqNo, primaryTerm;
         const { callWithRequest: ismGetPolicyRequest } = await this.esDriver.getCluster(CLUSTER.ISM);
@@ -113,76 +104,9 @@ export default class ManagedIndexService {
           managedIndexMetaData: transformManagedIndexMetaData(explain),
         });
       }
-      console.log(`check managedIndices content ${JSON.stringify(managedIndices)}`);
 
       return { ok: true, response: { managedIndices, totalManagedIndices: explainResponse.totalManagedIndices } };
     } catch (err) {
-      console.error("Index Management - ManagedIndexService - getManagedIndices", err);
-      return { ok: false, error: err.message };
-    }
-  };
-
-  getManagedIndices = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
-    try {
-      const { from, size, search, sortDirection, sortField } = req.query as {
-        from: string;
-        size: string;
-        search: string;
-        sortDirection: string;
-        sortField: string;
-      };
-
-      const managedIndexSorts: ManagedIndicesSort = { index: "managed_index.index", policyId: "managed_index.policy_id" };
-      const searchParams: RequestParams.Search = {
-        index: INDEX.OPENDISTRO_ISM_CONFIG,
-        seq_no_primary_term: true,
-        body: {
-          size,
-          from,
-          sort: managedIndexSorts[sortField] ? [{ [managedIndexSorts[sortField]]: sortDirection }] : [],
-          query: {
-            bool: {
-              filter: [{ exists: { field: "managed_index" } }],
-              must: getMustQuery("managed_index.name", search),
-            },
-          },
-        },
-      };
-
-      const { callWithRequest } = await this.esDriver.getCluster(CLUSTER.DATA);
-      const searchResponse: SearchResponse<any> = await callWithRequest(req, "search", searchParams);
-
-      const indices = searchResponse.hits.hits.map((hit) => hit._source.managed_index.index);
-      const totalManagedIndices = _.get(searchResponse, "hits.total.value", 0);
-
-      if (!indices.length) {
-        return { ok: true, response: { managedIndices: [], totalManagedIndices: 0 } };
-      }
-
-      const explainParams = { index: indices.join(",") };
-      const { callWithRequest: ismCallWithRequest } = await this.esDriver.getCluster(CLUSTER.ISM);
-      const explainResponse: ExplainResponse = await ismCallWithRequest(req, "ism.explain", explainParams);
-      const managedIndices = searchResponse.hits.hits.map((hit) => {
-        const index = hit._source.managed_index.index;
-        return {
-          index,
-          indexUuid: hit._source.managed_index.index_uuid,
-          policyId: hit._source.managed_index.policy_id,
-          policySeqNo: hit._source.managed_index.policy_seq_no,
-          policyPrimaryTerm: hit._source.managed_index.policy_primary_term,
-          policy: hit._source.managed_index.policy,
-          enabled: hit._source.managed_index.enabled,
-          managedIndexMetaData: transformManagedIndexMetaData(explainResponse[index]), // this will be undefined if we are initializing
-        };
-      });
-
-      console.log(`check managedIndices content ${JSON.stringify(managedIndices)}`);
-
-      return { ok: true, response: { managedIndices, totalManagedIndices } };
-    } catch (err) {
-      if (err.statusCode === 404 && err.body.error.type === "index_not_found_exception") {
-        return { ok: true, response: { managedIndices: [], totalManagedIndices: 0 } };
-      }
       console.error("Index Management - ManagedIndexService - getManagedIndices", err);
       return { ok: false, error: err.message };
     }

--- a/server/services/ManagedIndexService.ts
+++ b/server/services/ManagedIndexService.ts
@@ -57,7 +57,7 @@ export default class ManagedIndexService {
     }
   };
 
-  getManagedIndices = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
+  getManagedIndices2 = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
     // console.log('get managedindices request', req);
 
     try {
@@ -81,15 +81,13 @@ export default class ManagedIndexService {
         queryString: search ? `*${search.split(" ").join("* *")}*` : null,
       };
 
-      const { callWithRequest: ismExplainRequest } = await this.esDriver.getCluster(CLUSTER.ISM);
-      const explainResponse: ExplainResponse = await ismExplainRequest(req, "ism.explainAll", explainParams);
+      const { callWithRequest: ismExplainAllRequest } = await this.esDriver.getCluster(CLUSTER.ISM);
+      const explainResponse: ExplainResponse = await ismExplainAllRequest(req, "ism.explainAll", explainParams);
 
       const managedIndices = [];
       for (const index in explainResponse) {
         console.log(`index ${index}`);
-        if (index === "totalManagedIndices") {
-          break;
-        }
+        if (index === "totalManagedIndices") continue;
 
         const explain = explainResponse[index] as ExplainAPIManagedIndexMetaData;
         console.log(`explain index: ${explain.index}`);
@@ -108,15 +106,79 @@ export default class ManagedIndexService {
           index: index,
           indexUuid: explain.index_uuid,
           policyId: explain.policy_id,
-          policy: policy,
           policySeqNo: seqNo,
           policyPrimaryTerm: primaryTerm,
+          policy: policy,
           enabled: true,
           managedIndexMetaData: transformManagedIndexMetaData(explain),
         });
       }
+      console.log(`check managedIndices content ${JSON.stringify(managedIndices)}`);
 
       return { ok: true, response: { managedIndices, totalManagedIndices: explainResponse.totalManagedIndices } };
+    } catch (err) {
+      console.error("Index Management - ManagedIndexService - getManagedIndices", err);
+      return { ok: false, error: err.message };
+    }
+  };
+
+  getManagedIndices = async (req: Request, h: ResponseToolkit): Promise<ServerResponse<GetManagedIndicesResponse>> => {
+    try {
+      const { from, size, search, sortDirection, sortField } = req.query as {
+        from: string;
+        size: string;
+        search: string;
+        sortDirection: string;
+        sortField: string;
+      };
+
+      const managedIndexSorts: ManagedIndicesSort = { index: "managed_index.index", policyId: "managed_index.policy_id" };
+      const searchParams: RequestParams.Search = {
+        index: INDEX.OPENDISTRO_ISM_CONFIG,
+        seq_no_primary_term: true,
+        body: {
+          size,
+          from,
+          sort: managedIndexSorts[sortField] ? [{ [managedIndexSorts[sortField]]: sortDirection }] : [],
+          query: {
+            bool: {
+              filter: [{ exists: { field: "managed_index" } }],
+              must: getMustQuery("managed_index.name", search),
+            },
+          },
+        },
+      };
+
+      const { callWithRequest } = await this.esDriver.getCluster(CLUSTER.DATA);
+      const searchResponse: SearchResponse<any> = await callWithRequest(req, "search", searchParams);
+
+      const indices = searchResponse.hits.hits.map((hit) => hit._source.managed_index.index);
+      const totalManagedIndices = _.get(searchResponse, "hits.total.value", 0);
+
+      if (!indices.length) {
+        return { ok: true, response: { managedIndices: [], totalManagedIndices: 0 } };
+      }
+
+      const explainParams = { index: indices.join(",") };
+      const { callWithRequest: ismCallWithRequest } = await this.esDriver.getCluster(CLUSTER.ISM);
+      const explainResponse: ExplainResponse = await ismCallWithRequest(req, "ism.explain", explainParams);
+      const managedIndices = searchResponse.hits.hits.map((hit) => {
+        const index = hit._source.managed_index.index;
+        return {
+          index,
+          indexUuid: hit._source.managed_index.index_uuid,
+          policyId: hit._source.managed_index.policy_id,
+          policySeqNo: hit._source.managed_index.policy_seq_no,
+          policyPrimaryTerm: hit._source.managed_index.policy_primary_term,
+          policy: hit._source.managed_index.policy,
+          enabled: hit._source.managed_index.enabled,
+          managedIndexMetaData: transformManagedIndexMetaData(explainResponse[index]), // this will be undefined if we are initializing
+        };
+      });
+
+      console.log(`check managedIndices content ${JSON.stringify(managedIndices)}`);
+
+      return { ok: true, response: { managedIndices, totalManagedIndices } };
     } catch (err) {
       if (err.statusCode === 404 && err.body.error.type === "index_not_found_exception") {
         return { ok: true, response: { managedIndices: [], totalManagedIndices: 0 } };


### PR DESCRIPTION
*Issue #, if available:*
#129 

*Description of changes:*
previously we directly access config index when getManagedIndices, this will be blocked if security plugin comes in place, so we modified our backend explain API [PR 306](https://github.com/opendistro-for-elasticsearch/index-management/pull/306) to suit the use cases of frontend, so the access can be controlled in the backend.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
