### PR TITLE
Change release workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -59,11 +59,17 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
+
       - name: Upload Artifacts to S3
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp ${{ steps.build_zip.outputs.zip_path }} $s3_path/kibana-plugins/opendistro-index-management/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths '/downloads/*'
+          zip=${{ steps.build_zip.outputs.zip_path }}
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/kibana-plugins/index-management/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
       - name: Create Github Draft Release
         id: create_release
         uses: actions/create-release@v1.0.0


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS REQUEST UNTIL ASKED. We need to coordinate the merge with updating Github secrets.

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip artifact to staging.artifacts.opendistroforelasticsearch.amazon.com. The write to S3 currently fails because the secrets have not been updated; the secrets will be updated at the same time this PR is merged.

I do not have the GITHUB_KIBANA_OSS token so I was not able to verify that the workflow runs up to the S3 write.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
