### PR TITLE
Bug fix for duplicate dimension/metrics items and deletion error

### DIFF
--- a/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
+++ b/public/pages/CreateRollup/containers/CreateRollupForm/CreateRollupForm.tsx
@@ -86,6 +86,7 @@ interface CreateRollupFormState {
 
 export default class CreateRollupForm extends Component<CreateRollupFormProps, CreateRollupFormState> {
   static contextType = CoreServicesContext;
+
   constructor(props: CreateRollupFormProps) {
     super(props);
 
@@ -431,6 +432,10 @@ export default class CreateRollupForm extends Component<CreateRollupFormProps, C
   updateDimension = (): void => {
     const { rollupJSON, selectedDimensionField } = this.state;
     let newJSON = rollupJSON;
+
+    //Clear the dimensions fields except the first item (date histogram)
+    newJSON.rollup.dimensions = rollupJSON.rollup.dimensions.splice(0, 1);
+
     //Push rest of dimensions
     selectedDimensionField.map((dimension) => {
       if (dimension.aggregationMethod == "terms") {
@@ -454,6 +459,10 @@ export default class CreateRollupForm extends Component<CreateRollupFormProps, C
   updateMetric = (): void => {
     const { rollupJSON, selectedMetrics } = this.state;
     let newJSON = rollupJSON;
+
+    //Clear the metrics array before pushing
+    newJSON.rollup.metrics = [];
+
     //Push all metrics
     selectedMetrics.map((metric) => {
       const metrics = [];

--- a/server/services/RollupService.ts
+++ b/server/services/RollupService.ts
@@ -91,7 +91,7 @@ export default class RollupService {
       const params: DeleteRollupParams = { rollupId: id };
       const { callAsCurrentUser: callWithRequest } = this.esDriver.asScoped(request);
       const deleteRollupResponse: DeleteRollupResponse = await callWithRequest("ism.deleteRollup", params);
-      if (response.result !== "deleted") {
+      if (deleteRollupResponse.result !== "deleted") {
         return response.custom({
           statusCode: 200,
           body: {


### PR DESCRIPTION
*Issue #, if available: N/A*

*Description of changes:*
1. Duplicate dimension/metrics items

Upon creation, the dimension and metrics list are pushed to the JSON string of rollup. Reset array of dimensions and metrics to avoid items being duplicated. 

The logic is added to `updateDimension()` and `updateMetric()`, and both functions are pushing selected dimension/metric items to corresponding arrays in JSON object. The 2 functions are only called when attempt to create a rollup job. If an error occurs during creation, the 2 functions will be called again and redo the push of items. So, without the clearing, items will be pushed again and result in duplicates in JSON arrays. 

2. Deletion error

The delete rollup API was throwing error upon successful deletion because of mismatching response name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
