### PR TITLE
Wrap index name without truncating

### DIFF
--- a/public/pages/Indices/utils/constants.tsx
+++ b/public/pages/Indices/utils/constants.tsx
@@ -44,7 +44,7 @@ export const indicesColumns: EuiTableFieldDataColumnType<ManagedCatIndex>[] = [
     field: "index",
     name: "Index",
     sortable: true,
-    truncateText: true,
+    truncateText: false,
     textOnly: true,
     width: "250px",
     render: (index: string) => <span title={index}>{index}</span>,


### PR DESCRIPTION
*Issue #, if available:*
#114 

*Description of changes:*
Before the change, we were truncating the index name and hence index name was not shown fully. 
Post this change we are wrapping the text around.

Before:
<img width="539" alt="Screenshot 2021-03-14 at 12 20 50 PM" src="https://user-images.githubusercontent.com/1469191/111060453-060df800-84c3-11eb-9f74-6252afc6a80d.png">

After:
<img width="530" alt="Screenshot 2021-03-14 at 12 20 59 PM" src="https://user-images.githubusercontent.com/1469191/111060455-0a3a1580-84c3-11eb-89cc-e66d41824b5f.png">


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

