### PR TITLE
Reduce duplicate code in Rollup Pages 

### DIFF
--- a/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
+++ b/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
@@ -1,9 +1,15 @@
-import React  from "react";
+import React, {Fragment} from "react";
 
 import {
+  EuiFlexItem,
+  EuiText,
+  EuiBasicTable,
   EuiTableFieldDataColumnType,
+  EuiPanel,
+  EuiFlexGroup,
   EuiIcon,
 } from "@elastic/eui";
+
 import {DimensionItem, MetricItem} from "../../../models/interfaces";
 
 export const AGGREGATION_AND_METRIC_SETTINGS = 'Aggregation and metrics settings'
@@ -88,3 +94,73 @@ export const BaseMetricsColumns: Readonly<EuiTableFieldDataColumnType<MetricItem
   },
 ];
 
+export function  sequenceTableComponents(selectedDimensionField, items, columns, pagination, sorting, onChange) {
+  if(selectedDimensionField.length == 0) {
+   return (
+     <EuiText>
+       <dd>No fields added for aggregation</dd>
+     </EuiText>
+   )
+  }
+
+  return  (<Fragment>
+      <EuiPanel>
+        <EuiBasicTable
+          items={items}
+          rowHeader="sequence"
+          columns={columns}
+          tableLayout="auto"
+          noItemsMessage="No fields added for aggregations"
+          pagination={pagination}
+          sorting={sorting}
+          onChange={onChange}
+        />
+      </EuiPanel>
+    </Fragment>
+  )
+}
+
+export function additionalMetricsComponent(selectedMetrics) {
+  return (
+    <EuiFlexGroup gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <EuiText>
+          <h3>Additional metrics</h3>
+        </EuiText>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiText color="subdued" textAlign="left">
+          <h3>{`(${selectedMetrics.length})`}</h3>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  )
+}
+
+export function sourceFieldComponents(selectedMetrics, items, columns, pagination, sorting, onChange) {
+
+  if(selectedMetrics.length == 0) {
+    return (
+      <EuiText>
+        <dd>No fields added for metrics</dd>
+      </EuiText>
+    )
+  }
+
+   return (
+     <Fragment>
+      <EuiPanel>
+        <EuiBasicTable
+          items={items}
+          rowHeader="source_field"
+          columns={columns}
+          tableLayout="auto"
+          pagination={pagination}
+          sorting={sorting}
+          onChange={onChange}
+          noItemsMessage="No fields added for metrics"
+        />
+      </EuiPanel>
+     </Fragment>
+     )
+}

--- a/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
+++ b/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
@@ -1,0 +1,88 @@
+import React  from "react";
+
+import {
+  EuiTableFieldDataColumnType,
+  EuiIcon,
+} from "@elastic/eui";
+import {DimensionItem, MetricItem} from "../../../models/interfaces";
+
+export interface BaseAggregationAndMetricsState {
+  from: number;
+  size: number;
+  sortField: string;
+  sortDirection: string;
+  dimensionFrom: number;
+  dimensionSize: number;
+  dimensionSortField: string;
+  dimensionSortDirection: string;
+}
+
+
+export const BaseAggregationColumns:  Readonly<EuiTableFieldDataColumnType<DimensionItem>>[] = [
+  {
+    field: "sequence",
+    name: "Sequence",
+    sortable: true,
+    align: "left",
+    dataType: "number",
+  },
+  {
+    field: "field.label",
+    name: "Field name",
+    align: "left",
+  },
+  {
+    field: "aggregationMethod",
+    name: "Aggregation method",
+    align: "left",
+  },
+  {
+    field: "interval",
+    name: "Interval",
+    dataType: "number",
+    align: "left",
+    render: (interval: null | number) => {
+      if (interval == null) return "-";
+      else return `${interval}`;
+    },
+  },
+];
+
+
+export const BaseMetricsColumns: Readonly<EuiTableFieldDataColumnType<MetricItem>>[] = [
+  {
+    field: "source_field",
+    name: "Field Name",
+  },
+  {
+    field: "min",
+    name: "Min",
+    align: "center",
+    render: (min: boolean) => min && <EuiIcon type="check" />,
+  },
+  {
+    field: "max",
+    name: "Max",
+    align: "center",
+    render: (max: boolean) => max && <EuiIcon type="check" />,
+  },
+  {
+    field: "sum",
+    name: "Sum",
+    align: "center",
+    render: (sum: boolean) => sum && <EuiIcon type="check" />,
+  },
+  {
+    field: "avg",
+    name: "Avg",
+    align: "center",
+    render: (avg: boolean) => avg && <EuiIcon type="check" />,
+  },
+  {
+    field: "value_count",
+    name: "Value count",
+    align: "center",
+    render: (value_count: boolean) => value_count && <EuiIcon type="check" />,
+  },
+];
+

--- a/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
+++ b/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 import React, {Fragment} from "react";
 
 import {

--- a/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
+++ b/public/pages/Commons/BaseAggregationAndMetricSettings.tsx
@@ -6,6 +6,8 @@ import {
 } from "@elastic/eui";
 import {DimensionItem, MetricItem} from "../../../models/interfaces";
 
+export const AGGREGATION_AND_METRIC_SETTINGS = 'Aggregation and metrics settings'
+
 export interface BaseAggregationAndMetricsState {
   from: number;
   size: number;

--- a/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
+++ b/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
@@ -37,6 +37,7 @@ import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../utils/helpers";
 import { DimensionItem, MetricItem } from "../../../../../models/interfaces";
 import {
+  AGGREGATION_AND_METRIC_SETTINGS,
   BaseAggregationAndMetricsState,
   BaseAggregationColumns, BaseMetricsColumns
 } from "../../../Commons/BaseAggregationAndMetricSettings";
@@ -202,7 +203,7 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
           </ModalConsumer>
         }
         bodyStyles={{ padding: "initial" }}
-        title="Aggregation and metrics settings"
+        title={AGGREGATION_AND_METRIC_SETTINGS}
         titleSize="m"
       >
         <div style={{ padding: "15px" }}>

--- a/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
+++ b/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
@@ -36,6 +36,10 @@ import { ModalConsumer } from "../../../../components/Modal";
 import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../utils/helpers";
 import { DimensionItem, MetricItem } from "../../../../../models/interfaces";
+import {
+  BaseAggregationAndMetricsState,
+  BaseAggregationColumns, BaseMetricsColumns
+} from "../../../Commons/BaseAggregationAndMetricSettings";
 
 interface HistogramAndMetricsProps {
   rollupId: string;
@@ -49,97 +53,35 @@ interface HistogramAndMetricsProps {
   selectedMetrics: MetricItem[];
 }
 
-interface HistogramAndMetricsState {
-  from: number;
-  size: number;
-  sortField: string;
-  sortDirection: string;
+interface HistogramAndMetricsState extends BaseAggregationAndMetricsState {
   metricsShown: MetricItem[];
-  dimensionFrom: number;
-  dimensionSize: number;
-  dimensionSortField: string;
-  dimensionSortDirection: string;
   dimensionsShown: DimensionItem[];
 }
 
-const aggregationColumns: EuiTableFieldDataColumnType<DimensionItem>[] = [
-  {
-    field: "sequence",
-    name: "Sequence",
-    sortable: true,
-    align: "left",
-    dataType: "number",
-  },
-  {
-    field: "field.label",
-    name: "Field name",
-    align: "left",
-  },
+
+const _createFlowAggregateColumns: Readonly<EuiTableFieldDataColumnType<DimensionItem>>[] = [
   {
     field: "field.type",
     name: "Field type",
     align: "left",
     render: (type) => (type == undefined ? "-" : type),
   },
-  {
-    field: "aggregationMethod",
-    name: "Aggregation method",
-    align: "left",
-  },
-  {
-    field: "interval",
-    name: "Interval",
-    dataType: "number",
-    align: "left",
-    render: (interval: null | number) => {
-      if (interval == null) return "-";
-      else return `${interval}`;
-    },
-  },
-];
+]
 
-const metricsColumns: EuiTableFieldDataColumnType<MetricItem>[] = [
-  {
-    field: "source_field.label",
-    name: "Field Name",
-  },
-  {
+const _createFlowMetricsColumn: Readonly<EuiTableFieldDataColumnType<MetricItem>> =  {
     field: "all",
     name: "All",
     align: "center",
     render: (all: boolean) => all && <EuiIcon type="check" />,
-  },
-  {
-    field: "min",
-    name: "Min",
-    align: "center",
-    render: (min: boolean) => min && <EuiIcon type="check" />,
-  },
-  {
-    field: "max",
-    name: "Max",
-    align: "center",
-    render: (max: boolean) => max && <EuiIcon type="check" />,
-  },
-  {
-    field: "sum",
-    name: "Sum",
-    align: "center",
-    render: (sum: boolean) => sum && <EuiIcon type="check" />,
-  },
-  {
-    field: "avg",
-    name: "Avg",
-    align: "center",
-    render: (avg: boolean) => avg && <EuiIcon type="check" />,
-  },
-  {
-    field: "value_count",
-    name: "Value count",
-    align: "center",
-    render: (value_count: boolean) => value_count && <EuiIcon type="check" />,
-  },
-];
+  }
+
+
+const aggregationColumns: Readonly<EuiTableFieldDataColumnType<DimensionItem>>[]
+  = [...BaseAggregationColumns,..._createFlowAggregateColumns];
+
+// Adding 'all' column at 1st index.
+const metricsColumns: EuiTableFieldDataColumnType<MetricItem>[] =
+  [...BaseMetricsColumns].splice(1, 0, _createFlowMetricsColumn);
 
 export default class HistogramAndMetrics extends Component<HistogramAndMetricsProps, HistogramAndMetricsState> {
   constructor(props: HistogramAndMetricsProps) {

--- a/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
+++ b/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
@@ -13,16 +13,14 @@
  * permissions and limitations under the License.
  */
 
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import {
   EuiComboBoxOptionOption,
   EuiFlexGrid,
   EuiFlexItem,
   EuiSpacer,
   EuiText,
-  EuiBasicTable,
   EuiTableFieldDataColumnType,
-  EuiPanel,
   EuiFlexGroup,
   // @ts-ignore
   Criteria,
@@ -37,9 +35,10 @@ import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../utils/helpers";
 import { DimensionItem, MetricItem } from "../../../../../models/interfaces";
 import {
+  additionalMetricsComponent,
   AGGREGATION_AND_METRIC_SETTINGS,
   BaseAggregationAndMetricsState,
-  BaseAggregationColumns, BaseMetricsColumns
+  BaseAggregationColumns, BaseMetricsColumns, sequenceTableComponents, sourceFieldComponents
 } from "../../../Commons/BaseAggregationAndMetricSettings";
 
 interface HistogramAndMetricsProps {
@@ -246,61 +245,22 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          {selectedDimensionField.length ? (
-            <Fragment>
-              <EuiPanel>
-                <EuiBasicTable
-                  items={dimensionsShown}
-                  rowHeader="sequence"
-                  columns={aggregationColumns}
-                  tableLayout="auto"
-                  noItemsMessage="No fields added for aggregations"
-                  pagination={dimensionPagination}
-                  sorting={dimensionSorting}
-                  onChange={this.onDimensionTableChange}
-                />
-              </EuiPanel>
-            </Fragment>
-          ) : (
-            <EuiText>
-              <dd>No fields added for aggregation</dd>
-            </EuiText>
-          )}
+          {
+            sequenceTableComponents( selectedDimensionField, dimensionsShown, aggregationColumns,
+              dimensionPagination, dimensionSorting, this.onDimensionTableChange )
+          }
+
           <EuiSpacer size="m" />
 
           <EuiSpacer />
-          <EuiFlexGroup gutterSize="xs">
-            <EuiFlexItem grow={false}>
-              <EuiText>
-                <h3>Additional metrics</h3>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText color="subdued" textAlign="left">
-                <h3>{`(${selectedMetrics.length})`}</h3>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          {selectedMetrics.length ? (
-            <Fragment>
-              <EuiPanel>
-                <EuiBasicTable
-                  items={metricsShown}
-                  rowHeader="source_field"
-                  columns={metricsColumns}
-                  tableLayout="auto"
-                  pagination={pagination}
-                  sorting={sorting}
-                  onChange={this.onTableChange}
-                  noItemsMessage="No fields added for metrics"
-                />
-              </EuiPanel>
-            </Fragment>
-          ) : (
-            <EuiText>
-              <dd>No fields added for metrics</dd>
-            </EuiText>
-          )}
+          {
+            additionalMetricsComponent(selectedMetrics)
+          }
+
+          {
+            sourceFieldComponents(selectedMetrics, metricsShown, metricsColumns, pagination,
+                                  sorting, this.onTableChange)
+          }
 
           <EuiSpacer size="s" />
         </div>

--- a/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
+++ b/public/pages/CreateRollup/components/HistogramAndMetrics/HistogramAndMetrics.tsx
@@ -260,7 +260,7 @@ export default class HistogramAndMetrics extends Component<HistogramAndMetricsPr
           </ModalConsumer>
         }
         bodyStyles={{ padding: "initial" }}
-        title="Aggregation and metrics setting"
+        title="Aggregation and metrics settings"
         titleSize="m"
       >
         <div style={{ padding: "15px" }}>

--- a/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
+++ b/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
@@ -13,15 +13,13 @@
  * permissions and limitations under the License.
  */
 
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import {
   EuiFlexGrid,
   EuiSpacer,
   EuiFlexItem,
   EuiText,
   EuiFlexGroup,
-  EuiPanel,
-  EuiBasicTable,
   EuiTableFieldDataColumnType,
   //@ts-ignore
   Criteria,
@@ -34,10 +32,11 @@ import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../../CreateRollup/utils/helpers";
 import { DimensionItem, FieldItem, MetricItem } from "../../../../../models/interfaces";
 import {
+  additionalMetricsComponent,
   AGGREGATION_AND_METRIC_SETTINGS,
   BaseAggregationAndMetricsState,
   BaseAggregationColumns,
-  BaseMetricsColumns
+  BaseMetricsColumns, sequenceTableComponents, sourceFieldComponents
 } from "../../../Commons/BaseAggregationAndMetricSettings";
 
 interface AggregationAndMetricsSettingsProps {
@@ -185,61 +184,23 @@ export default class AggregationAndMetricsSettings extends Component<
             </EuiFlexItem>
           </EuiFlexGroup>
 
-          {selectedDimensionField.length ? (
-            <Fragment>
-              <EuiPanel>
-                <EuiBasicTable
-                  items={dimensionsShown}
-                  rowHeader="sequence"
-                  columns={aggregationColumns}
-                  tableLayout="auto"
-                  noItemsMessage="No fields added for aggregations"
-                  pagination={dimensionPagination}
-                  sorting={dimensionSorting}
-                  onChange={this.onDimensionTableChange}
-                />
-              </EuiPanel>
-            </Fragment>
-          ) : (
-            <EuiText>
-              <dd>No fields added for aggregation</dd>
-            </EuiText>
-          )}
+          {
+            sequenceTableComponents(selectedDimensionField, dimensionsShown, aggregationColumns,
+              dimensionPagination, dimensionSorting, this.onDimensionTableChange)
+          }
+
           <EuiSpacer size="m" />
 
           <EuiSpacer />
-          <EuiFlexGroup gutterSize="xs">
-            <EuiFlexItem grow={false}>
-              <EuiText>
-                <h3>Additional metrics</h3>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>
-              <EuiText color="subdued" textAlign="left">
-                <h3>{`(${selectedMetrics.length})`}</h3>
-              </EuiText>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          {selectedMetrics.length ? (
-            <Fragment>
-              <EuiPanel>
-                <EuiBasicTable
-                  items={metricsShown}
-                  rowHeader="source_field"
-                  columns={metricsColumns}
-                  tableLayout="auto"
-                  pagination={pagination}
-                  sorting={sorting}
-                  onChange={this.onTableChange}
-                  noItemsMessage="No fields added for metrics"
-                />
-              </EuiPanel>
-            </Fragment>
-          ) : (
-            <EuiText>
-              <dd>No fields added for metrics</dd>
-            </EuiText>
-          )}
+
+          {
+            additionalMetricsComponent(selectedMetrics)
+          }
+
+          {
+            sourceFieldComponents(selectedMetrics, metricsShown, metricsColumns, pagination,
+              sorting, this.onTableChange)
+          }
           <EuiSpacer size="s" />
         </div>
       </ContentPanel>

--- a/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
+++ b/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
@@ -22,7 +22,6 @@ import {
   EuiFlexGroup,
   EuiPanel,
   EuiBasicTable,
-  EuiIcon,
   EuiTableFieldDataColumnType,
   //@ts-ignore
   Criteria,
@@ -34,6 +33,11 @@ import { ContentPanel } from "../../../../components/ContentPanel";
 import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../../CreateRollup/utils/helpers";
 import { DimensionItem, FieldItem, MetricItem } from "../../../../../models/interfaces";
+import {
+  BaseAggregationAndMetricsState,
+  BaseAggregationColumns,
+  BaseMetricsColumns
+} from "../../../Commons/BaseAggregationAndMetricSettings";
 
 interface AggregationAndMetricsSettingsProps {
   timestamp: string;
@@ -47,83 +51,12 @@ interface AggregationAndMetricsSettingsProps {
   onChangeMetricsShown: (from: number, size: number) => void;
 }
 
-interface AggregationAndMetricsSettingsState {
-  from: number;
-  size: number;
-  sortField: string;
-  sortDirection: string;
-  dimensionFrom: number;
-  dimensionSize: number;
-  dimensionSortField: string;
-  dimensionSortDirection: string;
+interface AggregationAndMetricsSettingsState extends BaseAggregationAndMetricsState {
 }
 
-const aggregationColumns: EuiTableFieldDataColumnType<DimensionItem>[] = [
-  {
-    field: "sequence",
-    name: "Sequence",
-    sortable: true,
-    align: "left",
-    dataType: "number",
-  },
-  {
-    field: "field.label",
-    name: "Field name",
-    align: "left",
-  },
-  {
-    field: "aggregationMethod",
-    name: "Aggregation method",
-    align: "left",
-  },
-  {
-    field: "interval",
-    name: "Interval",
-    dataType: "number",
-    align: "left",
-    render: (interval: null | number) => {
-      if (interval == null) return "-";
-      else return `${interval}`;
-    },
-  },
-];
+const aggregationColumns: Readonly<EuiTableFieldDataColumnType<DimensionItem>>[] = BaseAggregationColumns;
 
-const metricsColumns = [
-  {
-    field: "source_field",
-    name: "Field Name",
-  },
-  {
-    field: "min",
-    name: "Min",
-    align: "center",
-    render: (min: boolean) => min && <EuiIcon type="check" />,
-  },
-  {
-    field: "max",
-    name: "Max",
-    align: "center",
-    render: (max: boolean) => max && <EuiIcon type="check" />,
-  },
-  {
-    field: "sum",
-    name: "Sum",
-    align: "center",
-    render: (sum: boolean) => sum && <EuiIcon type="check" />,
-  },
-  {
-    field: "avg",
-    name: "Avg",
-    align: "center",
-    render: (avg: boolean) => avg && <EuiIcon type="check" />,
-  },
-  {
-    field: "value_count",
-    name: "Value count",
-    align: "center",
-    render: (value_count: boolean) => value_count && <EuiIcon type="check" />,
-  },
-];
+const metricsColumns = BaseMetricsColumns;
 
 export default class AggregationAndMetricsSettings extends Component<
   AggregationAndMetricsSettingsProps,

--- a/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
+++ b/public/pages/RollupDetails/components/AggregationAndMetricsSettings/AggregationAndMetricsSettings.tsx
@@ -34,6 +34,7 @@ import { DEFAULT_PAGE_SIZE_OPTIONS } from "../../../Rollups/utils/constants";
 import { parseTimeunit } from "../../../CreateRollup/utils/helpers";
 import { DimensionItem, FieldItem, MetricItem } from "../../../../../models/interfaces";
 import {
+  AGGREGATION_AND_METRIC_SETTINGS,
   BaseAggregationAndMetricsState,
   BaseAggregationColumns,
   BaseMetricsColumns
@@ -140,7 +141,11 @@ export default class AggregationAndMetricsSettings extends Component<
       interval = intervalValue[0] + " " + parseTimeunit(intervalUnit[0]);
     }
     return (
-      <ContentPanel bodyStyles={{ padding: "initial" }} title="Aggregation and metrics settings" titleSize="m">
+      <ContentPanel
+        bodyStyles={{ padding: "initial" }}
+        title={AGGREGATION_AND_METRIC_SETTINGS}
+        titleSize="m"
+      >
         <div style={{ paddingLeft: "10px" }}>
           <EuiSpacer size="s" />
           <EuiText>


### PR DESCRIPTION
*Issue #, if available:*
#163 

*Description of changes:*
Refactor common code Rollup pages of Aggregation and Metrics settings. The changes separate out the common code into `BaseMetricsColumns` and refer from there. This PR hasn't done any logical changes and hence there are  some code pieces left intact in `HistogramsAndMetricsSetting` and `AggregationAndMetricsSettings` to avoid changing anything logical. `BaseMetricsColumns` is not made Super class in technical terms so as to avoid bloating of the logic handling in `BaseMetricsColumns` and it is simply used as Constant/Utils file here.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

