### PR TITLE
Refactored UX based on feedback and to better align with mockups.

### DIFF
--- a/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
+++ b/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
@@ -88,7 +88,14 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
             {aggItems()}
           </EuiFlexGrid>
           <EuiSpacer />
-          <EuiAccordion id="" buttonContent="Sample source index and transform result"></EuiAccordion>
+          <EuiAccordion
+            id=""
+            buttonContent={
+              <EuiText>
+                <h3>Sample source index and transform result</h3>
+              </EuiText>
+            }
+          ></EuiAccordion>
         </div>
       </ContentPanel>
     );

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -30,8 +30,9 @@ import {
   EuiAccordion,
   EuiHorizontalRule,
 } from "@elastic/eui";
-import { DelayTimeunitOptions, ScheduleIntervalTimeunitOptions } from "../../utils/constants";
+import { DelayTimeunitOptions, ExecutionFrequencyDefinitionOptions, ScheduleIntervalTimeunitOptions } from "../../utils/constants";
 import { ContentPanel } from "../../../../components/ContentPanel";
+import { selectInterval } from "../../../Transforms/utils/metadataHelper";
 
 interface ScheduleProps {
   isEdit: boolean;
@@ -58,37 +59,6 @@ const radios = [
     label: "Yes",
   },
 ];
-
-const selectInterval = (
-  interval: number,
-  intervalTimeunit: string,
-  intervalError: string,
-  onChangeInterval: (e: ChangeEvent<HTMLInputElement>) => void,
-  onChangeTimeunit: (value: ChangeEvent<HTMLSelectElement>) => void
-) => (
-  <React.Fragment>
-    <EuiFlexGroup style={{ maxWidth: 400 }}>
-      <EuiFlexItem grow={false} style={{ width: 200 }}>
-        <EuiFormRow label="Transform interval" error={intervalError} isInvalid={intervalError != ""}>
-          <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFormRow hasEmptyLabelSpace={true}>
-          <EuiSelect
-            id="selectIntervalTimeunit"
-            options={ScheduleIntervalTimeunitOptions}
-            value={intervalTimeunit}
-            onChange={onChangeTimeunit}
-            isInvalid={interval == undefined || interval <= 0}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </React.Fragment>
-);
-
-const timezones = moment.tz.names().map((tz) => ({ label: tz, text: tz }));
 
 export default class Schedule extends Component<ScheduleProps> {
   constructor(props: ScheduleProps) {
@@ -124,15 +94,24 @@ export default class Schedule extends Component<ScheduleProps> {
 
           {!isEdit}
 
-          <EuiFormRow label="Transform execution frequency">
-            <EuiSelect id="continuousDefinition" options={[{ value: "fixed", text: "Define by fixed interval" }]} />
-          </EuiFormRow>
-          <EuiSpacer size="m" />
+          {/* TODO: Removing transform execution frequency dropdown menu as only fix interval will be supported in P0. */}
+          {/*<EuiFormRow label="Transform execution frequency">*/}
+          {/*  <EuiSelect id="continuousDefinition" options={ExecutionFrequencyDefinitionOptions} />*/}
+          {/*</EuiFormRow>*/}
+          {/*<EuiSpacer size="m" />*/}
 
+          {/* TODO: Replace with switch block when define by cron expressions is supported. */}
           {selectInterval(interval, intervalTimeunit, intervalError, onChangeIntervalTime, onChangeIntervalTimeunit)}
 
           <EuiHorizontalRule />
-          <EuiAccordion id="pagePerExecution" buttonContent="Advanced">
+          <EuiAccordion
+            id="pagePerExecution"
+            buttonContent={
+              <EuiText>
+                <h3>Advanced</h3>
+              </EuiText>
+            }
+          >
             <EuiFormRow
               label="Page per execution"
               helpText="The number of pages every execution processes. A larger number means faster execution and higher costs on memory."

--- a/public/pages/CreateTransform/utils/constants.ts
+++ b/public/pages/CreateTransform/utils/constants.ts
@@ -75,3 +75,8 @@ export const AddFieldsColumns = [
     render: (type: string | undefined) => (type == null || type == undefined ? "-" : type),
   },
 ];
+
+export const ExecutionFrequencyDefinitionOptions = [
+  { value: "fixed", text: "Define by fixed interval" },
+  { value: "cron", text: "Define by cron expression" },
+];

--- a/public/pages/Transforms/components/Indices/Indices.tsx
+++ b/public/pages/Transforms/components/Indices/Indices.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { Component } from "react";
-import { EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText } from "@elastic/eui";
+import { EuiCodeEditor, EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText } from "@elastic/eui";
 import { ContentPanel } from "../../../../components/ContentPanel";
 
 interface IndicesProps {
@@ -24,32 +24,32 @@ interface IndicesProps {
 }
 
 export default class Indices extends Component<IndicesProps> {
- constructor(props: IndicesProps) {
-   super(props);
- }
+  constructor(props: IndicesProps) {
+    super(props);
+  }
 
- render() {
-   const { sourceIndex, targetIndex, sourceIndexFilter } = this.props;
+  render() {
+    const { sourceIndex, targetIndex, sourceIndexFilter } = this.props;
 
-   return (
-     <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
-      <div style={{ paddingLeft: "10px" }}>
-        <EuiText size="xs">
-          <dt>Source index</dt>
-          <dd>{sourceIndex}</dd>
-        </EuiText>
-        <EuiSpacer size="m" />
-        <EuiText size="xs">
-          <dt>Source index filter</dt>
-          <dd>{sourceIndexFilter}</dd>
-        </EuiText>
-        <EuiSpacer size="m" />
-        <EuiText size="xs">
-          <dt>Target index</dt>
-          <dd>{targetIndex}</dd>
-        </EuiText>
-      </div>
-     </ContentPanel>
-   )
- }
+    return (
+      <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
+        <div style={{ paddingLeft: "10px" }}>
+          <EuiText size="xs">
+            <dt>Source index</dt>
+            <dd>{sourceIndex}</dd>
+          </EuiText>
+          <EuiSpacer size="m" />
+          <EuiText size="xs">
+            <dt>Source index filter</dt>
+            <EuiCodeEditor mode="json" theme="github" width="400px" height="100px" value={sourceIndexFilter} readOnly />
+          </EuiText>
+          <EuiSpacer size="m" />
+          <EuiText size="xs">
+            <dt>Target index</dt>
+            <dd>{targetIndex}</dd>
+          </EuiText>
+        </div>
+      </ContentPanel>
+    );
+  }
 }

--- a/public/pages/Transforms/components/Schedule/Schedule.tsx
+++ b/public/pages/Transforms/components/Schedule/Schedule.tsx
@@ -25,11 +25,13 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTextArea,
+  EuiText,
 } from "@elastic/eui";
 // @ts-ignore
 import { htmlIdGenerator } from "@elastic/eui/lib/services";
 import { ScheduleIntervalTimeunitOptions } from "../../utils/constants";
 import { ContentPanel } from "../../../../components/ContentPanel";
+import { selectCronExpression, selectInterval } from "../../utils/metadataHelper";
 
 interface ScheduleProps {
   transformId: string;
@@ -50,37 +52,6 @@ interface ScheduleProps {
   onIntervalChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onIntervalTimeUnitChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 }
-
-const selectInterval = (
-  interval: number,
-  intervalTimeunit: string,
-  intervalError: string,
-  onIntervalChange: (e: ChangeEvent<HTMLInputElement>) => void,
-  onIntervalTimeUnitChange: (value: ChangeEvent<HTMLSelectElement>) => void
-) => (
-  <React.Fragment>
-    <EuiFlexGroup style={{ maxWidth: 400 }}>
-      <EuiFlexItem grow={false} style={{ width: 200 }}>
-        <EuiFormRow label="Transform interval" error={intervalError} isInvalid={intervalError != ""}>
-          <EuiFieldNumber value={interval} onChange={onIntervalChange} isInvalid={intervalError != ""} />
-        </EuiFormRow>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiFormRow hasEmptyLabelSpace={true}>
-          <EuiSelect
-            id="selectIntervalTimeunit"
-            options={ScheduleIntervalTimeunitOptions}
-            value={intervalTimeunit}
-            onChange={onIntervalTimeUnitChange}
-            isInvalid={interval == undefined || interval <= 0}
-          />
-        </EuiFormRow>
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  </React.Fragment>
-);
-
-const timezones = moment.tz.names().map((tz) => ({ label: tz, text: tz }));
 
 // TODO: Check wording for page size form with UX team
 export default class Schedule extends Component<ScheduleProps> {
@@ -131,22 +102,20 @@ export default class Schedule extends Component<ScheduleProps> {
           </EuiFormRow>
           <EuiSpacer size="m" />
 
-          {schedule == "fixed" ? (
-            selectInterval(interval, intervalTimeUnit, intervalError, onIntervalChange, onIntervalTimeUnitChange)
-          ) : (
-            <React.Fragment>
-              <EuiFormRow label="Define by cron expression">
-                <EuiTextArea value={cronExpression} onChange={onCronExpressionChange} compressed={true} />
-              </EuiFormRow>
-              <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
-                <EuiSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
-              </EuiFormRow>
-            </React.Fragment>
-          )}
+          {schedule == "fixed"
+            ? selectInterval(interval, intervalTimeUnit, intervalError, onIntervalChange, onIntervalTimeUnitChange)
+            : selectCronExpression(cronExpression, onCronExpressionChange, cronTimeZone, onCronTimeZoneChange)}
 
           <EuiSpacer size="m" />
 
-          <EuiAccordion id={htmlIdGenerator()()} buttonContent={"Advanced"}>
+          <EuiAccordion
+            id={htmlIdGenerator()()}
+            buttonContent={
+              <EuiText>
+                <h3>Advanced</h3>
+              </EuiText>
+            }
+          >
             <EuiFormRow
               label={"Pages per execution"}
               helpText={

--- a/public/pages/Transforms/containers/Transforms/TransformSettings.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformSettings.tsx
@@ -127,7 +127,15 @@ export default class TransformSettings extends Component<TransformSettingsProps,
           </EuiFlexGrid>
           <EuiSpacer size="m" />
         </div>
-        <EuiAccordion id={htmlIdGenerator()()} buttonContent={"Sample source index and transform result"} onClick={this.onClick}>
+        <EuiAccordion
+          id={htmlIdGenerator()()}
+          buttonContent={
+            <EuiText>
+              <h3>Sample source index and transform result</h3>
+            </EuiText>
+          }
+          onClick={this.onClick}
+        >
           <div style={{ paddingLeft: "10px" }}>
             <EuiSpacer size={"s"} />
 

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -13,9 +13,11 @@
  * permissions and limitations under the License.
  */
 
-import {TransformMetadata} from "../../../../models/interfaces";
-import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from "@elastic/eui";
+import { TransformMetadata } from "../../../../models/interfaces";
+import React, { ChangeEvent } from "react";
+import moment from "moment-timezone";
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiFormRow, EuiSelect, EuiTextArea, EuiText } from "@elastic/eui";
+import { ScheduleIntervalTimeunitOptions } from "../../CreateTransform/utils/constants";
 
 // TODO: merge with rollup helper to have a common helper
 export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Element => {
@@ -39,7 +41,7 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
       break;
     case "init":
       return (
-        <EuiFlexGroup gutterSize="xs">
+        <EuiFlexGroup gutterSize="xs" alignItems={"center"}>
           <EuiFlexItem grow={false}>
             <EuiIcon size="s" type="clock" color="primary" />
           </EuiFlexItem>
@@ -67,7 +69,7 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
   }
 
   return (
-    <EuiFlexGroup gutterSize="xs">
+    <EuiFlexGroup gutterSize="xs" alignItems={"center"}>
       <EuiFlexItem grow={false}>
         <EuiIcon size="s" type={icon} color={iconColor} />
       </EuiFlexItem>
@@ -83,3 +85,50 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
 export const renderEnabled = (isEnabled: boolean): string => {
   return isEnabled ? "Enabled" : "Disabled";
 };
+
+export const selectInterval = (
+  interval: number,
+  intervalTimeunit: string,
+  intervalError: string,
+  onChangeInterval: (e: ChangeEvent<HTMLInputElement>) => void,
+  onChangeTimeunit: (value: ChangeEvent<HTMLSelectElement>) => void
+) => (
+  <React.Fragment>
+    <EuiFlexGroup style={{ maxWidth: 400 }}>
+      <EuiFlexItem grow={false} style={{ width: 200 }}>
+        <EuiFormRow label="Transform execution interval" error={intervalError} isInvalid={intervalError != ""}>
+          <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFormRow hasEmptyLabelSpace={true}>
+          <EuiSelect
+            id="selectIntervalTimeunit"
+            options={ScheduleIntervalTimeunitOptions}
+            value={intervalTimeunit}
+            onChange={onChangeTimeunit}
+            isInvalid={interval == undefined || interval <= 0}
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </React.Fragment>
+);
+
+export const selectCronExpression = (
+  cronExpression: string,
+  onCronExpressionChange: (e: ChangeEvent<HTMLTextAreaElement>) => void,
+  cronTimeZone: string,
+  onCronTimeZoneChange: (e: ChangeEvent<HTMLSelectElement>) => void
+) => (
+  <React.Fragment>
+    <EuiFormRow label="Define by cron expression">
+      <EuiTextArea value={cronExpression} onChange={onCronExpressionChange} compressed={true} />
+    </EuiFormRow>
+    <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
+      <EuiSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
+    </EuiFormRow>
+  </React.Fragment>
+);
+
+export const timezones = moment.tz.names().map((tz) => ({ label: tz, text: tz }));

--- a/public/pages/Transforms/utils/metadataHelper.tsx
+++ b/public/pages/Transforms/utils/metadataHelper.tsx
@@ -13,9 +13,11 @@
  * permissions and limitations under the License.
  */
 
-import {TransformMetadata} from "../../../../models/interfaces";
-import React from "react";
-import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText } from "@elastic/eui";
+import { TransformMetadata } from "../../../../models/interfaces";
+import React, { ChangeEvent } from "react";
+import moment from "moment-timezone";
+import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiFormRow, EuiSelect, EuiTextArea, EuiText } from "@elastic/eui";
+import { ScheduleIntervalTimeunitOptions } from "../../CreateTransform/utils/constants";
 
 // TODO: merge with rollup helper to have a common helper
 export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Element => {
@@ -39,7 +41,7 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
       break;
     case "init":
       return (
-        <EuiFlexGroup gutterSize="xs">
+        <EuiFlexGroup gutterSize="xs" alignItems="center">
           <EuiFlexItem grow={false}>
             <EuiIcon size="s" type="clock" color="primary" />
           </EuiFlexItem>
@@ -67,7 +69,7 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
   }
 
   return (
-    <EuiFlexGroup gutterSize="xs">
+    <EuiFlexGroup gutterSize="xs" alignItems="center">
       <EuiFlexItem grow={false}>
         <EuiIcon size="s" type={icon} color={iconColor} />
       </EuiFlexItem>
@@ -83,3 +85,50 @@ export const renderStatus = (metadata: TransformMetadata | undefined): JSX.Eleme
 export const renderEnabled = (isEnabled: boolean): string => {
   return isEnabled ? "Enabled" : "Disabled";
 };
+
+export const selectInterval = (
+  interval: number,
+  intervalTimeunit: string,
+  intervalError: string,
+  onChangeInterval: (e: ChangeEvent<HTMLInputElement>) => void,
+  onChangeTimeunit: (value: ChangeEvent<HTMLSelectElement>) => void
+) => (
+  <React.Fragment>
+    <EuiFlexGroup style={{ maxWidth: 400 }}>
+      <EuiFlexItem grow={false} style={{ width: 200 }}>
+        <EuiFormRow label="Transform execution interval" error={intervalError} isInvalid={intervalError != ""}>
+          <EuiFieldNumber value={interval} onChange={onChangeInterval} isInvalid={intervalError != ""} />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFormRow hasEmptyLabelSpace={true}>
+          <EuiSelect
+            id="selectIntervalTimeunit"
+            options={ScheduleIntervalTimeunitOptions}
+            value={intervalTimeunit}
+            onChange={onChangeTimeunit}
+            isInvalid={interval == undefined || interval <= 0}
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  </React.Fragment>
+);
+
+export const selectCronExpression = (
+  cronExpression: string,
+  onCronExpressionChange: (e: ChangeEvent<HTMLTextAreaElement>) => void,
+  cronTimeZone: string,
+  onCronTimeZoneChange: (e: ChangeEvent<HTMLSelectElement>) => void
+) => (
+  <React.Fragment>
+    <EuiFormRow label="Define by cron expression">
+      <EuiTextArea value={cronExpression} onChange={onCronExpressionChange} compressed={true} />
+    </EuiFormRow>
+    <EuiFormRow label="Timezone" helpText="A day starts from 00:00:00 in the specified timezone.">
+      <EuiSelect id="timezone" options={timezones} value={cronTimeZone} onChange={onCronTimeZoneChange} />
+    </EuiFormRow>
+  </React.Fragment>
+);
+
+export const timezones = moment.tz.names().map((tz) => ({ label: tz, text: tz }));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Removed the dropdown menu from the **Step 3** of transform creation, `Specify Schedule` as only `Define by fixed interval` will be supported for P0. Screenshot below. **NOTE:** `Define by cron expression` is still available when **editing** an existing transform. We may want to remove that dropdown option as well.
<img width="1129" alt="Screen Shot 2021-05-17 at 6 31 06 PM" src="https://user-images.githubusercontent.com/79280347/118577057-92949b00-b73e-11eb-9313-0fd8c1f479fa.png">
2. Refactored accordion button content to use header 3 style to better align with the style used in the mockups.
<img width="464" alt="Screen Shot 2021-05-17 at 6 28 39 PM" src="https://user-images.githubusercontent.com/79280347/118577168-be178580-b73e-11eb-8b12-a869ebb627f4.png">
3. Center-aligned the icons with their corresponding labels.
<img width="368" alt="Screen Shot 2021-05-17 at 6 28 26 PM" src="https://user-images.githubusercontent.com/79280347/118577221-d8e9fa00-b73e-11eb-966b-47a341e69b12.png">
4. Refactored the index filter value on the edit transform page to be displayed in a code block.
<img width="486" alt="Screen Shot 2021-05-17 at 6 30 08 PM" src="https://user-images.githubusercontent.com/79280347/118577286-fe770380-b73e-11eb-882f-ee0ce24199d4.png">
5. Moved some functions and logic to helper classes, and moved the list of supported schedule definition options to a constants class to reduce duplicated code.
         


_ 
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

