### PR TITLE
Review aggregate and group on Create Transform now matches mock

### DIFF
--- a/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
+++ b/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
@@ -17,7 +17,7 @@ import React, { Component } from "react";
 import { EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText, EuiAccordion } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { ModalConsumer } from "../../../../components/Modal";
-import { TransformGroupItem } from "../../../../../models/interfaces";
+import { TransformGroupItem, DimensionItem } from "../../../../../models/interfaces";
 
 interface ReviewDefinitionProps {
   selectedGroupField: TransformGroupItem[];
@@ -30,29 +30,67 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
     super(props);
   }
 
+
+
   render() {
     const { selectedGroupField, selectedAggregations, onChangeStep } = this.props;
 
     const groupItems = () => {
       return selectedGroupField.map((group) => {
+        let parsedGroup = parseGroup(group);
         return (
           <EuiFlexItem>
             <EuiText size="xs">
-              <dt>Group</dt>
-              <dd>{JSON.stringify(group)}</dd>
+              <dt>Group by {parsedGroup.aggregationMethod}</dt>
+              <dd>{parsedGroup.field.label}</dd>
             </EuiText>
           </EuiFlexItem>
         );
       });
     };
 
+    const parseGroup = (group: TransformGroupItem): DimensionItem => {
+      switch (true) {
+        case group.date_histogram != null:
+          return {
+            sequence: 0,
+            aggregationMethod: "date_histogram",
+            field: {
+              label: group.date_histogram?.source_field,
+            },
+            interval: group.date_histogram?.interval,
+          };
+        case group.histogram != null:
+          return {
+            sequence: 0,
+            aggregationMethod: "histogram",
+            field: {
+              label: group.histogram?.source_field,
+            },
+            interval: group.histogram?.interval,
+          };
+        case group.terms != null:
+          return {
+            sequence: 0,
+            aggregationMethod: "terms",
+            field: {
+              label: group.terms?.source_field,
+            },
+            interval: null,
+          };
+      }
+    }
+
     const aggItems = () => {
       return Object.keys(selectedAggregations).map((key) => {
+        let aggregationType = Object.keys(selectedAggregations[key])[0];
+        let sourceField = selectedAggregations[key][aggregationType].field;
+
         return (
           <EuiFlexItem>
             <EuiText size="xs">
-              <dt>{key}</dt>
-              <dd>{JSON.stringify(selectedAggregations[key])}</dd>
+              <dt>{aggregationType}()</dt>
+              <dd>{sourceField}</dd>
             </EuiText>
           </EuiFlexItem>
         );
@@ -83,7 +121,7 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
       >
         <div style={{ padding: "15px" }}>
           <EuiSpacer size="s" />
-          <EuiFlexGrid columns={1}>
+          <EuiFlexGrid columns={4}>
             {groupItems()}
             {aggItems()}
           </EuiFlexGrid>


### PR DESCRIPTION
*Description of changes:*
In Create Transform flow, on review page (step 4) display for aggregates and groups now matches mock.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

