### PR TITLE
Tables on create transform review page

### DIFF
--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -60,7 +60,7 @@ export default function DefineTransforms({
   fields.map((field: FieldItem) => {
     columns.push({
       id: field.label,
-      display: (
+      display: !isReadOnly && (
         <TransformOptions
           name={field.label}
           type={field.type}
@@ -281,6 +281,52 @@ export default function DefineTransforms({
     return "-";
   };
 
+  //TODO: remove duplicate code here after extracting the first table as separate component
+  if (isReadOnly)
+    return (
+      <div>
+        <EuiText>
+          <h4>Original fields with sample data</h4>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <EuiDataGrid
+          aria-label="Define transforms"
+          columns={columns}
+          columnVisibility={{ visibleColumns, setVisibleColumns }}
+          rowCount={Math.min(dataCount, DefaultSampleDataSize)}
+          renderCellValue={renderCellValue}
+          sorting={{ columns: sortingColumns, onSort }}
+          pagination={{
+            ...pagination,
+            pageSizeOptions: [5, 10, 20, 50],
+            onChangeItemsPerPage: onChangeItemsPerPage,
+            onChangePage: onChangePage,
+          }}
+          toolbarVisibility={{
+            showColumnSelector: true,
+            showStyleSelector: false,
+            showSortSelector: false,
+            showFullScreenSelector: false,
+          }}
+        />
+        <EuiSpacer />
+        <EuiText>
+          <h4>Transformed fields preview based on sample data</h4>
+        </EuiText>
+        <EuiSpacer size="s" />
+        <PreviewTransform
+          previewTransform={previewTransform}
+          selectedGroupField={selectedGroupField}
+          onGroupSelectionChange={onGroupSelectionChange}
+          aggList={aggList}
+          selectedAggregations={selectedAggregations}
+          onAggregationSelectionChange={onAggregationSelectionChange}
+          onRemoveTransformation={onRemoveTransformation}
+          isReadOnly={isReadOnly}
+        />
+      </div>
+    );
+
   return (
     <ContentPanel
       //TODO: Add action to enter full screen view
@@ -347,6 +393,7 @@ export default function DefineTransforms({
         selectedAggregations={selectedAggregations}
         onAggregationSelectionChange={onAggregationSelectionChange}
         onRemoveTransformation={onRemoveTransformation}
+        isReadOnly={isReadOnly}
       />
     </ContentPanel>
   );

--- a/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
+++ b/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
@@ -74,34 +74,54 @@ export default function PreviewTransform({
   );
 
   const updatePreviewColumns = (): void => {
-    if (aggList.length) {
-      let tempCol: EuiDataGridColumn[] = [];
-      aggList.map((aggItem) => {
-        tempCol.push({
-          id: aggItem.name,
-          display: !isReadOnly && (
-            <PreviewOptions
-              name={aggItem.name}
-              selectedGroupField={selectedGroupField}
-              onGroupSelectionChange={onGroupSelectionChange}
-              aggList={aggList}
-              selectedAggregations={selectedAggregations}
-              onAggregationSelectionChange={onAggregationSelectionChange}
-              onRemoveTransformation={onRemoveTransformation}
-            />
-          ),
-          actions: {
-            showHide: false,
-            showMoveLeft: false,
-            showMoveRight: false,
-            showSortAsc: false,
-            showSortDesc: false,
-          },
+    if (isReadOnly) {
+      if (previewTransform.length) {
+        let tempCol: EuiDataGridColumn[] = [];
+        for (const [key, value] of Object.entries(previewTransform[0])) {
+          tempCol.push({
+            id: key,
+            actions: {
+              showHide: false,
+              showMoveLeft: false,
+              showMoveRight: false,
+              showSortAsc: false,
+              showSortDesc: false,
+            },
+          });
+        }
+        setPreviewColumns(tempCol);
+        setVisiblePreviewColumns(() => tempCol.map(({ id }) => id).slice(0, 5));
+      }
+    } else {
+      if (aggList.length) {
+        let tempCol: EuiDataGridColumn[] = [];
+        aggList.map((aggItem) => {
+          tempCol.push({
+            id: aggItem.name,
+            display: !isReadOnly && (
+              <PreviewOptions
+                name={aggItem.name}
+                selectedGroupField={selectedGroupField}
+                onGroupSelectionChange={onGroupSelectionChange}
+                aggList={aggList}
+                selectedAggregations={selectedAggregations}
+                onAggregationSelectionChange={onAggregationSelectionChange}
+                onRemoveTransformation={onRemoveTransformation}
+              />
+            ),
+            actions: {
+              showHide: false,
+              showMoveLeft: false,
+              showMoveRight: false,
+              showSortAsc: false,
+              showSortDesc: false,
+            },
+          });
         });
-      });
 
-      setPreviewColumns(tempCol);
-      setVisiblePreviewColumns(() => tempCol.map(({ id }) => id).slice(0, 5));
+        setPreviewColumns(tempCol);
+        setVisiblePreviewColumns(() => tempCol.map(({ id }) => id).slice(0, 5));
+      }
     }
   };
 
@@ -109,7 +129,7 @@ export default function PreviewTransform({
     updatePreviewColumns();
   }, [previewTransform, aggList]);
 
-  return aggList.length ? (
+  return (!isReadOnly && aggList.length) || (isReadOnly && previewTransform.length) ? (
     <EuiDataGrid
       aria-label="Preview transforms"
       columns={previewColumns}

--- a/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
+++ b/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
@@ -27,6 +27,7 @@ interface PreviewTransformProps {
   selectedAggregations: any;
   onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
   onRemoveTransformation: (name: string) => void;
+  isReadOnly: boolean;
 }
 
 export default function PreviewTransform({
@@ -37,6 +38,7 @@ export default function PreviewTransform({
   aggList,
   onAggregationSelectionChange,
   onRemoveTransformation,
+  isReadOnly,
 }: PreviewTransformProps) {
   const [previewColumns, setPreviewColumns] = useState<EuiDataGridColumn[]>([]);
   const [visiblePreviewColumns, setVisiblePreviewColumns] = useState(() => previewColumns.map(({ id }) => id).slice(0, 5));
@@ -77,7 +79,7 @@ export default function PreviewTransform({
       aggList.map((aggItem) => {
         tempCol.push({
           id: aggItem.name,
-          display: (
+          display: !isReadOnly && (
             <PreviewOptions
               name={aggItem.name}
               selectedGroupField={selectedGroupField}

--- a/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
+++ b/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
@@ -17,11 +17,25 @@ import React, { Component } from "react";
 import { EuiFlexGrid, EuiSpacer, EuiFlexItem, EuiText, EuiAccordion } from "@elastic/eui";
 import { ContentPanel, ContentPanelActions } from "../../../../components/ContentPanel";
 import { ModalConsumer } from "../../../../components/Modal";
-import { TransformGroupItem, DimensionItem } from "../../../../../models/interfaces";
+import { TransformGroupItem, DimensionItem, FieldItem, TransformAggItem } from "../../../../../models/interfaces";
+import DefineTransforms from "../DefineTransforms";
+import { TransformService } from "../../../../services";
+import { CoreStart } from "kibana/public";
 
 interface ReviewDefinitionProps {
+  transformService: TransformService;
+  notifications: CoreStart["notifications"];
+  transformId: string;
+  sourceIndex: string;
+  fields: FieldItem[];
+  z;
   selectedGroupField: TransformGroupItem[];
+  onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
+  aggList: TransformAggItem[];
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onRemoveTransformation: (name: string) => void;
+  previewTransform: any[];
   onChangeStep: (step: number) => void;
 }
 
@@ -30,10 +44,22 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
     super(props);
   }
 
-
-
   render() {
-    const { selectedGroupField, selectedAggregations, onChangeStep } = this.props;
+    const {
+      transformService,
+      notifications,
+      transformId,
+      sourceIndex,
+      fields,
+      selectedGroupField,
+      onGroupSelectionChange,
+      selectedAggregations,
+      aggList,
+      onAggregationSelectionChange,
+      onRemoveTransformation,
+      previewTransform,
+      onChangeStep,
+    } = this.props;
 
     const groupItems = () => {
       return selectedGroupField.map((group) => {
@@ -79,7 +105,7 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
             interval: null,
           };
       }
-    }
+    };
 
     const aggItems = () => {
       return Object.keys(selectedAggregations).map((key) => {
@@ -133,7 +159,21 @@ export default class ReviewDefinition extends Component<ReviewDefinitionProps> {
                 <h3>Sample source index and transform result</h3>
               </EuiText>
             }
-          ></EuiAccordion>
+          >
+            <DefineTransforms
+              {...this.props}
+              transformService={transformService}
+              notifications={this.context.notifications}
+              transformId={transformId}
+              sourceIndex={sourceIndex}
+              fields={fields}
+              onGroupSelectionChange={onGroupSelectionChange}
+              selectedAggregations={selectedAggregations}
+              onAggregationSelectionChange={onAggregationSelectionChange}
+              onRemoveTransformation={onRemoveTransformation}
+              isReadOnly={true}
+            />
+          </EuiAccordion>
         </div>
       </ContentPanel>
     );

--- a/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
+++ b/public/pages/CreateTransform/components/ReviewDefinition/ReviewDefinition.tsx
@@ -28,7 +28,6 @@ interface ReviewDefinitionProps {
   transformId: string;
   sourceIndex: string;
   fields: FieldItem[];
-  z;
   selectedGroupField: TransformGroupItem[];
   onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;

--- a/public/pages/CreateTransform/components/Schedule/Schedule.tsx
+++ b/public/pages/CreateTransform/components/Schedule/Schedule.tsx
@@ -49,17 +49,6 @@ interface ScheduleProps {
   onChangePage: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const radios = [
-  {
-    id: "no",
-    label: "No",
-  },
-  {
-    id: "yes",
-    label: "Yes",
-  },
-];
-
 export default class Schedule extends Component<ScheduleProps> {
   constructor(props: ScheduleProps) {
     super(props);
@@ -79,7 +68,7 @@ export default class Schedule extends Component<ScheduleProps> {
       onChangePage,
     } = this.props;
     return (
-      <ContentPanel bodyStyles={{ padding: "initial" }} title="Schedule" titleSize="s">
+      <ContentPanel bodyStyles={{ padding: "initial" }} title="Schedule" titleSize="m">
         <div style={{ paddingLeft: "10px" }}>
           {!isEdit && (
             <EuiCheckbox

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -511,7 +511,6 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           currentStep={this.state.currentStep}
           sourceIndex={sourceIndex[0] ? sourceIndex[0].label : ""}
           fields={fields}
-          selectedTerms={selectedTerms}
           aggList={aggList}
           selectedGroupField={selectedGroupField}
           selectedAggregations={selectedAggregations}
@@ -541,8 +540,14 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           sourceIndex={sourceIndex}
           targetIndex={targetIndex}
           sourceIndexFilter={sourceIndexFilter}
+          fields={fields}
           selectedGroupField={selectedGroupField}
+          onGroupSelectionChange={this.onGroupSelectionChange}
           selectedAggregations={selectedAggregations}
+          aggList={aggList}
+          onAggregationSelectionChange={this.onAggregationSelectionChange}
+          onRemoveTransformation={this.onRemoveTransformation}
+          previewTransform={previewTransform}
           jobEnabledByDefault={jobEnabledByDefault}
           interval={interval}
           intervalTimeunit={intervalTimeunit}

--- a/public/pages/CreateTransform/containers/CreateTransformStep2/CreateTransformStep2.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformStep2/CreateTransformStep2.tsx
@@ -88,6 +88,7 @@ export default class CreateTransformStep2 extends Component<CreateTransformStep2
               selectedAggregations={selectedAggregations}
               onAggregationSelectionChange={onAggregationSelectionChange}
               onRemoveTransformation={onRemoveTransformation}
+              isReadOnly={false}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/pages/CreateTransform/containers/CreateTransformStep4/CreateTransformStep4.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformStep4/CreateTransformStep4.tsx
@@ -18,7 +18,7 @@ import { EuiSpacer, EuiTitle, EuiFlexGroup, EuiFlexItem, EuiComboBoxOptionOption
 import { RouteComponentProps } from "react-router-dom";
 import { TransformService } from "../../../../services";
 import { BREADCRUMBS, ROUTES } from "../../../../utils/constants";
-import { IndexItem, TransformGroupItem } from "../../../../../models/interfaces";
+import { FieldItem, IndexItem, TransformAggItem, TransformGroupItem } from "../../../../../models/interfaces";
 import CreateTransformSteps from "../../components/CreateTransformSteps";
 import JobNameAndIndices from "../../components/JobNameAndIndices";
 import ReviewDefinition from "../../components/ReviewDefinition";
@@ -36,15 +36,20 @@ interface CreateTransformProps extends RouteComponentProps {
   targetIndex: { label: string; value?: IndexItem }[];
   sourceIndexFilter: string;
 
+  jobEnabledByDefault: boolean;
+  pageSize: number;
+  fields: FieldItem[];
   selectedGroupField: TransformGroupItem[];
+  onGroupSelectionChange: (selectedFields: TransformGroupItem[], aggItem: TransformAggItem) => void;
   selectedAggregations: any;
+  aggList: TransformAggItem[];
+  onAggregationSelectionChange: (selectedFields: any, aggItem: TransformAggItem) => void;
+  onRemoveTransformation: (name: string) => void;
+  previewTransform: any[];
 
   timestamp: EuiComboBoxOptionOption<String>[];
   timezone: string;
   timeunit: string;
-
-  jobEnabledByDefault: boolean;
-  pageSize: number;
 }
 
 export default class CreateTransformStep4 extends Component<CreateTransformProps> {
@@ -77,7 +82,7 @@ export default class CreateTransformStep4 extends Component<CreateTransformProps
             <EuiSpacer />
             <JobNameAndIndices {...this.props} />
             <EuiSpacer />
-            <ReviewDefinition {...this.props} />
+            <ReviewDefinition {...this.props} notifications={this.context.notifications} sourceIndex={this.props.sourceIndex[0].label} />
             <EuiSpacer />
             <ReviewSchedule {...this.props} />
             <EuiSpacer />

--- a/public/pages/Transforms/containers/Transforms/TransformSettings.tsx
+++ b/public/pages/Transforms/containers/Transforms/TransformSettings.tsx
@@ -155,7 +155,7 @@ export default class TransformSettings extends Component<TransformSettingsProps,
               <h4>Preview result based on sample data</h4>
             </EuiText>
             <EuiSpacer size={"s"} />
-            <PreviewTransforms previewTransform={this.state.previewTransform} />
+            <PreviewTransforms previewTransform={this.state.previewTransform} aggList={[]} isReadOnly={true} />
           </div>
         </EuiAccordion>
       </ContentPanel>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding preview table to the review page of create transform.
Modified existing components with a `isReadOnly` property. May need some code clean up to reduce duplicate code in `DefineTransform` component

Screenshot: 
<img width="1164" alt="image" src="https://user-images.githubusercontent.com/71157062/118879255-19b84f00-b8b6-11eb-9ad8-5925514dda9f.png">

On details page:
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/71157062/118880689-c1824c80-b8b7-11eb-83f1-8346c129e8e0.png">

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

