### PR TITLE
Text modification and parse date fields on create step 2

### DIFF
--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -78,135 +78,6 @@ export default function DefineTransforms({
         showMoveRight: false,
         showSortAsc: false,
         showSortDesc: false,
-        // additional: [
-        //   {
-        //     label: "Group by histogram ",
-        //     onClick: () => {
-        //       const targetFieldName = `${field.label}_${GROUP_TYPES.histogram}`;
-        //       groupSelection.push({
-        //         histogram: {
-        //           source_field: field.label,
-        //           target_field: targetFieldName,
-        //           interval: 5,
-        //         },
-        //       });
-        //       onGroupSelectionChange(groupSelection);
-        //     },
-        //     size: "xs",
-        //     color: isNumeric ? "text" : "subdued",
-        //   },
-        //   {
-        //     label: "Group by date histogram ",
-        //     onClick: () => {
-        //       groupSelection.push({
-        //         date_histogram: {
-        //           source_field: field.label,
-        //           target_field: `${field.label}_${GROUP_TYPES.dateHistogram}`,
-        //           calendar_interval: "1d",
-        //         },
-        //       });
-        //       onGroupSelectionChange(groupSelection);
-        //     },
-        //     size: "xs",
-        //     color: isDate ? "text" : "subdued",
-        //   },
-        //   {
-        //     label: "Group by terms ",
-        //     onClick: () => {
-        //       groupSelection.push({
-        //         terms: {
-        //           source_field: field.label,
-        //           target_field: `${field.label}_${GROUP_TYPES.terms}`,
-        //         },
-        //       });
-        //       onGroupSelectionChange(groupSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by sum ",
-        //     onClick: () => {
-        //       aggSelection[`sum_${field.label}`] = {
-        //         sum: { field: field.label },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by max ",
-        //     onClick: () => {
-        //       aggSelection[`max_${field.label}`] = {
-        //         max: { field: field.label },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by min ",
-        //     onClick: () => {
-        //       aggSelection[`min_${field.label}`] = {
-        //         min: { field: field.label },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by avg ",
-        //     onClick: () => {
-        //       aggSelection[`avg_${field.label}`] = {
-        //         avg: { field: field.label },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by count ",
-        //     onClick: () => {
-        //       aggSelection[`count_${field.label}`] = {
-        //         value_count: { field: field.label },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by percentile",
-        //     onClick: () => {
-        //       aggSelection[`percentiles_${field.label}`] = {
-        //         percentiles: { field: field.label, percents: [1, 5, 25, 99] },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        //   {
-        //     label: "Aggregate by scripted metrics ",
-        //     onClick: () => {
-        //       aggSelection[`scripted_metric_${field.label}`] = {
-        //         scripted_metric: {
-        //           init_script: "",
-        //           map_script: "",
-        //           combine_script: "",
-        //           reduce_script: "",
-        //         },
-        //       };
-        //       onAggregationSelectionChange(aggSelection);
-        //     },
-        //     size: "xs",
-        //     color: "text",
-        //   },
-        // ],
       },
     });
   });
@@ -309,7 +180,7 @@ export default function DefineTransforms({
             showFullScreenSelector: false,
           }}
         />
-        <EuiSpacer />
+        <EuiSpacer size="s" />
         <EuiText>
           <h4>Transformed fields preview based on sample data</h4>
         </EuiText>
@@ -380,9 +251,13 @@ export default function DefineTransforms({
           showFullScreenSelector: false,
         }}
       />
-      <EuiSpacer />
+      <EuiSpacer size="s" />
       <EuiText>
         <h4>Transformed fields preview based on sample data</h4>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiText color="subdued" size="xs">
+        <p>This fields preview displays only the first 10 results of your transform job.</p>
       </EuiText>
       <EuiSpacer size="s" />
       <PreviewTransform

--- a/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
+++ b/public/pages/CreateTransform/components/DefineTransforms/DefineTransforms.tsx
@@ -23,6 +23,7 @@ import { getErrorMessage } from "../../../../utils/helpers";
 import PreviewTransform from "../PreviewTransform";
 import TransformOptions from "../TransformOptions";
 import { DefaultSampleDataSize } from "../../utils/constants";
+import { renderTime } from "../../../Transforms/utils/helpers";
 
 interface DefineTransformsProps {
   transformService: TransformService;
@@ -141,11 +142,12 @@ export default function DefineTransforms({
 
   const renderCellValue = ({ rowIndex, columnId }) => {
     if (!loading && data.hasOwnProperty(rowIndex)) {
-      // TODO: work on truncating the value to certain length defined by the keyword field
       if (columns?.find((column) => column.id == columnId).schema == "keyword") {
         // Remove the keyword postfix for getting correct data from array
         const correspondingTextColumnId = columnId.replace(".keyword", "");
         return data[rowIndex]._source[correspondingTextColumnId] ? data[rowIndex]._source[correspondingTextColumnId] : "-";
+      } else if (columns?.find((column) => column.id == columnId).schema == "date") {
+        return data[rowIndex]._source[columnId] ? renderTime(data[rowIndex]._source[columnId]) : "-";
       }
       return data[rowIndex]._source[columnId] ? data[rowIndex]._source[columnId] : "-";
     }

--- a/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
+++ b/public/pages/CreateTransform/components/IndexFilterPopover/IndexFilterPopover.tsx
@@ -36,7 +36,13 @@ interface IndexFilterPopoverProps {
   closePopover: () => void;
 }
 
-export default function IndexFilterPopover({ sourceIndex, fields, sourceIndexFilter, onChangeSourceIndexFilter, closePopover }: IndexFilterPopoverProps) {
+export default function IndexFilterPopover({
+  sourceIndex,
+  fields,
+  sourceIndexFilter,
+  onChangeSourceIndexFilter,
+  closePopover,
+}: IndexFilterPopoverProps) {
   const [selectedField, setSelectedField] = useState("");
   const [selectedOperator, setSelectedOperator] = useState("");
   const [selectedValue, setSelectedValue] = useState("");
@@ -95,7 +101,7 @@ export default function IndexFilterPopover({ sourceIndex, fields, sourceIndexFil
 
   function customEditor() {
     return (
-      <EuiFormRow label="Elasticsearch Query DSL">
+      <EuiFormRow label="Custom query DSL">
         <EuiCodeEditor value={queryDsl} onChange={(string) => setQueryDsl(string)} mode="json" width="100%" height="250px" />
       </EuiFormRow>
     );

--- a/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
+++ b/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
@@ -18,6 +18,7 @@ import { EuiDataGrid, EuiDataGridColumn } from "@elastic/eui";
 import PreviewEmptyPrompt from "../PreviewEmptyPrompt";
 import PreviewOptions from "../PreviewOptions";
 import { TransformAggItem, TransformGroupItem } from "../../../../../models/interfaces";
+import { renderTime } from "../../../Transforms/utils/helpers";
 
 interface PreviewTransformProps {
   previewTransform: any[];
@@ -47,6 +48,12 @@ export default function PreviewTransform({
   const renderPreviewCellValue = ({ rowIndex, columnId }) => {
     if (previewTransform.hasOwnProperty(rowIndex)) {
       if (previewTransform[rowIndex][columnId]) {
+        // Case for date histogram type
+        //TODO: Check if there's a better way to check for date histogram types
+        if (columnId.includes("date_histogram")) {
+          return renderTime(previewTransform[rowIndex][columnId]);
+        }
+
         // Case for percentile
         return typeof previewTransform[rowIndex][columnId] !== ("string" || "number")
           ? JSON.stringify(previewTransform[rowIndex][columnId])

--- a/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
+++ b/public/pages/CreateTransform/components/PreviewTransform/PreviewTransform.tsx
@@ -55,23 +55,6 @@ export default function PreviewTransform({
     }
     return "-";
   };
-  const onChangePreviewPerPage = useCallback(
-    (pageSize) => {
-      setPreviewPagination((previewPagination) => ({
-        ...previewPagination,
-        pageSize,
-        pageIndex: 0,
-      }));
-    },
-    [setPreviewPagination]
-  );
-
-  const onChangePreviewPage = useCallback(
-    (pageIndex) => {
-      setPreviewPagination((previewPagination) => ({ ...previewPagination, pageIndex }));
-    },
-    [setPreviewPagination]
-  );
 
   const updatePreviewColumns = (): void => {
     if (isReadOnly) {
@@ -136,12 +119,6 @@ export default function PreviewTransform({
       columnVisibility={{ visibleColumns: visiblePreviewColumns, setVisibleColumns: setVisiblePreviewColumns }}
       rowCount={previewTransform.length}
       renderCellValue={renderPreviewCellValue}
-      // pagination={{
-      //   ...previewPagination,
-      //   pageSizeOptions: [5, 10, 20, 50],
-      //   onChangeItemsPerPage: onChangePreviewPerPage,
-      //   onChangePage: onChangePreviewPage,
-      // }}
       toolbarVisibility={{
         showColumnSelector: true,
         showStyleSelector: false,

--- a/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
+++ b/public/pages/CreateTransform/components/TransformOptions/Panels/HistogramPanel/HistogramPanel.tsx
@@ -48,7 +48,7 @@ export default function HistogramPanel({ name, handleGroupSelectionChange, aggLi
             fill
             fullWidth={false}
             onClick={() => {
-              const targetFieldName = `${name} _${GROUP_TYPES.histogram}`;
+              const targetFieldName = `${name} _${GROUP_TYPES.histogram}_${histogramInterval}`;
               handleGroupSelectionChange(
                 {
                   histogram: {

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -273,6 +273,7 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
     this.setState({
       selectedGroupField: [],
       selectedAggregations: {},
+      aggList: [],
     });
     await this.getMappings(srcIndexText);
   };


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Added help text to and parse data fields on preview table on step 2 of creation page.
- Rename Query DSL text on step 1. 
- Reset `aggList`when source index is changed. 
- Changed the default naming of "Group by histogram" target field to include numeric interval value. 
- Some code cleanup

Screenshots:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/71157062/119027967-8a21a780-b96c-11eb-8349-0dafb1dc2901.png">


<img width="1376" alt="image" src="https://user-images.githubusercontent.com/71157062/119027624-2eefb500-b96c-11eb-853e-83f4ab995edc.png">


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

