### PR TITLE
Fixed change source index warning conditional and added padding

### DIFF
--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -181,7 +181,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     return (
       <div>
         <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
-        <div style={{ paddingLeft: "10px" }}>
+        <div style={{ paddingLeft: "10px", paddingRight: "10px" }}>
           {hasAggregation && (
             <Fragment>
               <EuiSpacer size="s" />

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -181,7 +181,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     return (
       <div>
         <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
-        <div style={{ paddingLeft: "10px", paddingRight: "10px" }}>
+        <div style={{ paddingLeft: "10px", paddingRight: "64px" }}>
           {hasAggregation && (
             <Fragment>
               <EuiSpacer size="s" />

--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -181,6 +181,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     return (
       <div>
         <ContentPanel bodyStyles={{ padding: "initial" }} title="Indices" titleSize="m">
+        <div style={{ paddingLeft: "10px" }}>
           {hasAggregation && (
             <Fragment>
               <EuiSpacer size="s" />
@@ -189,8 +190,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
               </EuiCallOut>
             </Fragment>
           )}
-          <div style={{ paddingLeft: "10px" }}>
-            <EuiSpacer size="m" />
+            <EuiSpacer size="s" />
             <EuiFormRow
               label="Source index"
               error={sourceIndexError}

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -503,7 +503,9 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           onChangeSourceIndexFilter={this.onChangeSourceIndexFilter}
           onChangeTargetIndex={this.onChangeTargetIndex}
           currentStep={this.state.currentStep}
-          hasAggregation={selectedGroupField.length != 0 || Object.keys(selectedAggregations).length != 0}
+          hasAggregation={selectedGroupField.length != 0 ||
+            Object.keys(selectedAggregations).length != 0 ||
+            aggList.length != 0}
           fields={fields}
           beenWarned={beenWarned}
         />

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -503,7 +503,7 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
           onChangeSourceIndexFilter={this.onChangeSourceIndexFilter}
           onChangeTargetIndex={this.onChangeTargetIndex}
           currentStep={this.state.currentStep}
-          hasAggregation={selectedGroupField.length != 0 || selectedAggregations.length != 0}
+          hasAggregation={selectedGroupField.length != 0 || Object.keys(selectedAggregations).length != 0}
           fields={fields}
           beenWarned={beenWarned}
         />


### PR DESCRIPTION
*Description of changes:*
Source Index change warning now only appears if user has added an aggregation or group and returns to page 1. 
Warning now appears fully within content panel with expected padding.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

