### PR TITLE
Changed clear source index filter to empty string 

### DIFF
--- a/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
+++ b/public/pages/CreateTransform/components/TransformIndices/TransformIndices.tsx
@@ -175,7 +175,7 @@ export default class TransformIndices extends Component<TransformIndicesProps, T
     );
 
     const clearIndexFilter = () => {
-      onChangeSourceIndexFilter("{}");
+      onChangeSourceIndexFilter("");
     };
 
     return (

--- a/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
+++ b/public/pages/CreateTransform/containers/CreateTransformForm/CreateTransformForm.tsx
@@ -279,14 +279,18 @@ export default class CreateTransformForm extends Component<CreateTransformFormPr
   };
 
   //TODO: Change type from string to string[] or something else  when multiple data filter is supported
-  onChangeSourceIndexFilter = (sourceIndexFilter: string): void => {
+  onChangeSourceIndexFilter = (newFilter: string): void => {
     let newJSON = this.state.transformJSON;
-    try {
-      newJSON.transform.data_selection_query = JSON.parse(sourceIndexFilter);
-    } catch (err) {
-      this.context.notifications.toasts.addDanger('Invalid source index filter JSON: "' + sourceIndexFilter + '"');
+    if (newFilter == "") {
+      newJSON.transform.hasOwnProperty("data_selection_query") && delete newJSON.transform.data_selection_query
+    } else {
+      try {
+        newJSON.transform.data_selection_query = JSON.parse(newFilter);
+      } catch (err) {
+        this.context.notifications.toasts.addDanger('Invalid source index filter JSON: "' + newFilter + '"');
+      }
     }
-    this.setState({ sourceIndexFilter: sourceIndexFilter, transformJSON: newJSON });
+    this.setState({ sourceIndexFilter: newFilter, transformJSON: newJSON });
   };
 
   onChangeTargetIndex = (options: EuiComboBoxOptionOption<IndexItem>[]): void => {


### PR DESCRIPTION
*Issue #, if available:*
Bug on preview when cleared Source Index Filter

*Description of changes:*
Modified clear behavior to delete property entirely, returning to the default state instead of clearing to an empty query of "{}". 
Error was caused by "{}" being valid JSON but not a valid DSL filter query. 

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.

